### PR TITLE
avoid race conditions as part of travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - go tool vet .
   - golint -set_exit_status ./...
   - gofmt -l . | exit $(wc -l)
-  - go test -v ./... -cover
+  - go test -v ./... -cover -race
 
 notifications:
   slack:

--- a/rows.go
+++ b/rows.go
@@ -27,7 +27,13 @@ type rows struct {
 }
 
 func (r *rows) Run(ctx context.Context, inp, out chan Dataset) error {
-	r.Out = out                                   // save it for Next()
+	if r.Out != nil {
+		if r.Out != out {
+			panic("rows already have out")
+		}
+	} else {
+		r.Out = out // save it for Next()
+	}
 	r.Ctx, r.CancelFunc = context.WithCancel(ctx) // for Close()
 	return r.Runner.Run(r.Ctx, inp, out)
 }


### PR DESCRIPTION
pretty awesome go race detection :)

found one error. committing it separately so you can see detected race in [first travis log](https://travis-ci.org/panoplyio/ep/builds/292015912).