### PR TITLE
add sortableDataset to handle recurring columns

### DIFF
--- a/dataset_test.go
+++ b/dataset_test.go
@@ -1,8 +1,30 @@
 package ep
 
-import "testing"
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"sort"
+	"testing"
+)
 
 func TestDataInterface(t *testing.T) {
-	dataset := NewDataset(Null.Data(10), str.Data(10))
+	dataset := NewDataset(Null.Data(10), str.Data(10)).GetSortable()
 	VerifyDataInvariant(t, dataset)
+}
+
+func TestDatasetSort(t *testing.T) {
+	var d1 Data = strs([]string{"hello", "world", "foo", "bar"})
+	var d2 Data = strs([]string{"1", "2", "4", "3"})
+
+	dataset := newSortableDataset(dataset{d1, d2, d1, d2})
+	sort.Sort(dataset)
+
+	require.Equal(t, 4, dataset.Len())
+	require.Equal(t, 4, dataset.Width())
+
+	// sorting always done according last column
+	require.Equal(t, "[1 2 3 4]", fmt.Sprintf("%+v", dataset.At(dataset.Width()-1)))
+	// verify other columns were updated as well
+	require.Equal(t, "[hello world bar foo]", fmt.Sprintf("%+v", dataset.At(0)))
+	require.Equal(t, "[1 2 3 4]", fmt.Sprintf("%+v", dataset.At(1)))
 }

--- a/nulls.go
+++ b/nulls.go
@@ -36,6 +36,7 @@ func (vs nulls) Width() int                             { return 0 }
 func (vs nulls) At(int) Data                            { panic("runtime error: index out of range") }
 func (vs nulls) Expand(other Dataset) Dataset           { return other }
 func (vs nulls) Split(secondLen int) (Dataset, Dataset) { panic("runtime error: not splitable") }
+func (vs nulls) GetSortable() Dataset                   { return vs }
 
 // to-string, for debugging. Same as array of <nil>.
 func (vs nulls) String() string {


### PR DESCRIPTION
sometimes dataset can contain recurring columns, i.e. the underlying array of two different i, j columns is identical.
calling dataset[i].swap and dataset[j].swap will result in unsorted array.

therefore, i made dataset unsortable (panics on swap and less), and created an extension that calls swap and less only on unique columns. i.e. only once for each unique underlying array.

@avinoamr not sure if the new api is the best option, will be happy to hear what do you think. 10x :)