### PR TITLE
project runs and read from all runners without recursion

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -1,10 +1,12 @@
 package ep
 
 import (
+	"fmt"
 	"strings"
 )
 
 var _ = registerGob(NewDataset(), &datasetType{})
+var errMismatch = fmt.Errorf("mismatched number of rows")
 
 // Dataset is a composite Data interface, containing several internal Data
 // objects. It's a Data in itself, but allows traversing and manipulating the
@@ -20,7 +22,7 @@ type Dataset interface {
 
 	// Expand returns new dataset composed of this dataset's columns and other's
 	// columns. Number of rows of both datasets should be equal
-	Expand(other Dataset) Dataset
+	Expand(other Dataset) (Dataset, error)
 
 	// Split divides dataset to two parts, where the second part width determined by
 	// the given secondWidth argument
@@ -46,18 +48,18 @@ func (set dataset) At(i int) Data {
 }
 
 // Expand returns new dataset with set and other's columns
-func (set dataset) Expand(other Dataset) Dataset {
+func (set dataset) Expand(other Dataset) (Dataset, error) {
 	if set == nil {
-		return other
+		return other, nil
 	} else if other == nil {
-		return set
+		return set, nil
 	}
 	if set.Len() != other.Len() {
-		panic("Unable to expand mismatching number of rows")
+		return nil, errMismatch
 	}
 
 	otherCols := other.(dataset)
-	return append(set, otherCols...)
+	return append(set, otherCols...), nil
 }
 
 // Split returns two datasets, with requested second width

--- a/ep_test.go
+++ b/ep_test.go
@@ -26,7 +26,7 @@ func (r *infinityRunner) Run(ctx context.Context, inp, out chan Dataset) error {
 	// infinitely produce data, until canceled
 	for {
 		select {
-		case _, _ = <-ctx.Done():
+		case <-ctx.Done():
 			return nil
 		default:
 			out <- NewDataset(strs{"data"})

--- a/nulls.go
+++ b/nulls.go
@@ -28,7 +28,7 @@ func (vs nulls) Duplicate(t int) Data  { return vs * nulls(t) }
 func (vs nulls) Strings() []string     { return make([]string, vs) }
 
 // implements Dataset as well
-func (vs nulls) Width() int                   { return 0 }
-func (vs nulls) At(int) Data                  { panic("runtime error: index out of range") }
-func (vs nulls) Expand(other Dataset) Dataset { return other }
-func (vs nulls) Split(int) (Dataset, Dataset) { panic("runtime error: not splitable") }
+func (vs nulls) Width() int                            { return 0 }
+func (vs nulls) At(int) Data                           { panic("runtime error: index out of range") }
+func (vs nulls) Expand(other Dataset) (Dataset, error) { return other, nil }
+func (vs nulls) Split(int) (Dataset, Dataset)          { panic("runtime error: not splitable") }


### PR DESCRIPTION
project should read i-th batch from all runners, without letting some runners to proceed. 
old version using `runOne` recursion function allowed most left runner (at index 0) to proceed. 

bonus: Expand shouldn't panic on mismatch number of rows, but return suitable error