### PR TITLE
error handling

### DIFF
--- a/distribute_test.go
+++ b/distribute_test.go
@@ -14,14 +14,14 @@ func TestDistribute_success(t *testing.T) {
 	// avoid "bind: address already in use" error in future tests
 	defer time.Sleep(1 * time.Millisecond)
 
-	port1 := ":5551"
+	port1 := ":5561"
 	dist1 := mockPeer(t, port1)
 	defer dist1.Close()
 
-	port2 := ":5552"
+	port2 := ":5562"
 	defer mockPeer(t, port2).Close()
 
-	port3 := ":5553"
+	port3 := ":5563"
 	defer mockPeer(t, port3).Close()
 
 	runner := dist1.Distribute(Pipeline(Scatter(), Gather()), port1, port2, port3)
@@ -39,16 +39,16 @@ func TestDistribute_connectionError(t *testing.T) {
 	// avoid "bind: address already in use" error in future tests
 	defer time.Sleep(1 * time.Millisecond)
 
-	port1 := ":5551"
+	port1 := ":5561"
 	dist1 := mockPeer(t, port1)
 	defer dist1.Close()
 
-	runner := dist1.Distribute(&upper{}, port1, ":5552")
+	runner := dist1.Distribute(&upper{}, port1, ":5000")
 
 	data, err := TestRunner(runner, NewDataset())
 
 	require.Error(t, err)
-	require.Equal(t, "dial tcp :5552: getsockopt: connection refused", err.Error())
+	require.Equal(t, "dial tcp :5000: getsockopt: connection refused", err.Error())
 	require.Nil(t, data)
 }
 
@@ -57,11 +57,11 @@ func TestDistribute_errorFromPeer(t *testing.T) {
 	// avoid "bind: address already in use" error in future tests
 	defer time.Sleep(1 * time.Millisecond)
 
-	port1 := ":5551"
+	port1 := ":5561"
 	dist1 := mockPeer(t, port1)
 	defer dist1.Close()
 
-	port2 := ":5552"
+	port2 := ":5562"
 	defer mockPeer(t, port2).Close()
 
 	mightErrored := &dataRunner{NewDataset(), port2}
@@ -70,32 +70,6 @@ func TestDistribute_errorFromPeer(t *testing.T) {
 	data1 := NewDataset(strs{"hello", "world"})
 	data2 := NewDataset(strs{"foo", "bar"})
 	data, err := TestRunner(runner, data1, data2)
-
-	require.Error(t, err)
-	require.Equal(t, "error", err.Error())
-	require.Equal(t, 0, data.Width())
-}
-
-// Test that errors are transmitted across the network
-func _TestDistribute_errorFromPeerStopAllPeers(t *testing.T) {
-	port1 := ":5551"
-	dist1 := mockPeer(t, port1)
-	defer dist1.Close()
-
-	port2 := ":5552"
-	defer mockPeer(t, port2).Close()
-
-	port3 := ":5553"
-	defer mockPeer(t, port3).Close()
-
-	mightErrored := &dataRunner{NewDataset(), port2}
-	runner := dist1.Distribute(Pipeline(Scatter(), &nodeAddr{}, mightErrored, Gather()), port1, port2, port3)
-
-	data1 := NewDataset(strs{"hello", "world"})
-	data2 := NewDataset(strs{"foo", "bar"})
-	data, err := TestRunner(runner, data1, data2, data2, data2, data2, data2, data2, data2, data2, data2,
-		data2, data2, data2, data2, data2, data2, data2, data2, data2, data2, data2, data2, data2, data2,
-		data2, data2, data2, data2, data2, data2, data2, data2, data2, data2, data2)
 
 	require.Error(t, err)
 	require.Equal(t, "error", err.Error())

--- a/distribute_test.go
+++ b/distribute_test.go
@@ -75,3 +75,29 @@ func TestDistribute_errorFromPeer(t *testing.T) {
 	require.Equal(t, "error", err.Error())
 	require.Equal(t, 0, data.Width())
 }
+
+// Test that errors are transmitted across the network
+func _TestDistribute_errorFromPeerStopAllPeers(t *testing.T) {
+	port1 := ":5551"
+	dist1 := mockPeer(t, port1)
+	defer dist1.Close()
+
+	port2 := ":5552"
+	defer mockPeer(t, port2).Close()
+
+	port3 := ":5553"
+	defer mockPeer(t, port3).Close()
+
+	mightErrored := &dataRunner{NewDataset(), port2}
+	runner := dist1.Distribute(Pipeline(Scatter(), &nodeAddr{}, mightErrored, Gather()), port1, port2, port3)
+
+	data1 := NewDataset(strs{"hello", "world"})
+	data2 := NewDataset(strs{"foo", "bar"})
+	data, err := TestRunner(runner, data1, data2, data2, data2, data2, data2, data2, data2, data2, data2,
+		data2, data2, data2, data2, data2, data2, data2, data2, data2, data2, data2, data2, data2, data2,
+		data2, data2, data2, data2, data2, data2, data2, data2, data2, data2, data2)
+
+	require.Error(t, err)
+	require.Equal(t, "error", err.Error())
+	require.Equal(t, 0, data.Width())
+}

--- a/distribute_test.go
+++ b/distribute_test.go
@@ -1,0 +1,77 @@
+package ep
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var _ = registerGob(&upper{})
+var _ = registerGob(&dataRunner{})
+
+func TestDistribute_success(t *testing.T) {
+	// avoid "bind: address already in use" error in future tests
+	defer time.Sleep(1 * time.Millisecond)
+
+	port1 := ":5551"
+	dist1 := mockPeer(t, port1)
+	defer dist1.Close()
+
+	port2 := ":5552"
+	defer mockPeer(t, port2).Close()
+
+	port3 := ":5553"
+	defer mockPeer(t, port3).Close()
+
+	runner := dist1.Distribute(Pipeline(Scatter(), Gather()), port1, port2, port3)
+
+	data1 := NewDataset(strs{"hello", "world"})
+	data2 := NewDataset(strs{"foo", "bar"})
+	data, err := TestRunner(runner, data1, data2)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, data.Width())
+	require.Equal(t, "[hello world foo bar]", fmt.Sprintf("%v", data.At(0)))
+}
+
+func TestDistribute_connectionError(t *testing.T) {
+	// avoid "bind: address already in use" error in future tests
+	defer time.Sleep(1 * time.Millisecond)
+
+	port1 := ":5551"
+	dist1 := mockPeer(t, port1)
+	defer dist1.Close()
+
+	runner := dist1.Distribute(&upper{}, port1, ":5552")
+
+	data, err := TestRunner(runner, NewDataset())
+
+	require.Error(t, err)
+	require.Equal(t, "dial tcp :5552: getsockopt: connection refused", err.Error())
+	require.Nil(t, data)
+}
+
+// Test that errors are transmitted across the network
+func TestDistribute_errorFromPeer(t *testing.T) {
+	// avoid "bind: address already in use" error in future tests
+	defer time.Sleep(1 * time.Millisecond)
+
+	port1 := ":5551"
+	dist1 := mockPeer(t, port1)
+	defer dist1.Close()
+
+	port2 := ":5552"
+	defer mockPeer(t, port2).Close()
+
+	mightErrored := &dataRunner{NewDataset(), port2}
+	runner := dist1.Distribute(Pipeline(Scatter(), &nodeAddr{}, mightErrored, Gather()), port1, port2)
+
+	data1 := NewDataset(strs{"hello", "world"})
+	data2 := NewDataset(strs{"foo", "bar"})
+	data, err := TestRunner(runner, data1, data2)
+
+	require.Error(t, err)
+	require.Equal(t, "error", err.Error())
+	require.Equal(t, 0, data.Width())
+}

--- a/ep_test.go
+++ b/ep_test.go
@@ -2,6 +2,7 @@ package ep
 
 import (
 	"context"
+	"fmt"
 )
 
 var _ = registerGob(strs{})
@@ -36,6 +37,7 @@ func (r *infinityRunner) Run(ctx context.Context, inp, out chan Dataset) error {
 
 type dataRunner struct {
 	Dataset
+	ThrowOnData string
 }
 
 func (r *dataRunner) Returns() []Type {
@@ -46,7 +48,10 @@ func (r *dataRunner) Returns() []Type {
 	return types
 }
 func (r *dataRunner) Run(ctx context.Context, inp, out chan Dataset) error {
-	for range inp {
+	for data := range inp {
+		if r.ThrowOnData == data.At(data.Width() - 1).Strings()[0] {
+			return fmt.Errorf("error")
+		}
 	} // drains input
 	out <- r.Dataset
 	return nil

--- a/rows_test.go
+++ b/rows_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestRows(t *testing.T) {
 	data := NewDataset(strs([]string{"hello", "world"}))
-	runner := Pipeline(&dataRunner{data}, &upper{})
+	runner := Pipeline(&dataRunner{Dataset: data}, &upper{})
 	rows := Rows(context.Background(), runner).(driver.Rows)
 	cols := rows.Columns()
 	require.Equal(t, 1, len(cols))

--- a/test_utils.go
+++ b/test_utils.go
@@ -14,8 +14,7 @@ func TestRunner(r Runner, datasets ...Dataset) (Dataset, error) {
 
 // TestRunnerWithContext is helper function for tests, doing the same as TestRunner
 // with given context
-func TestRunnerWithContext(ctx context.Context, r Runner, datasets ...Dataset) (Dataset, error) {
-	var err error
+func TestRunnerWithContext(ctx context.Context, r Runner, datasets ...Dataset) (res Dataset, err error) {
 	inp := make(chan Dataset)
 	out := make(chan Dataset)
 	go func() {
@@ -34,10 +33,9 @@ func TestRunnerWithContext(ctx context.Context, r Runner, datasets ...Dataset) (
 		close(inp)
 	}()
 
-	var res = NewDataset()
+	res = NewDataset()
 	for data := range out {
 		res = res.Append(data).(Dataset)
 	}
-
 	return res, err
 }


### PR DESCRIPTION
This pr includes:
- exchange transmit only data, not errors
- distribute is in charge of collection all errors from peers

missing tests&behaviour:
- cancel query if error reported (rather than let local runner to run to the end)
- cancel other peers running if error reported