### PR TITLE
Remove the random sleep in tests.

### DIFF
--- a/test_utils.go
+++ b/test_utils.go
@@ -2,8 +2,6 @@ package ep
 
 import (
 	"context"
-	"math/rand"
-	"time"
 )
 
 // TestRunner is helper function for tests, that runs given runner with given
@@ -24,10 +22,6 @@ func TestRunnerWithContext(ctx context.Context, r Runner, datasets ...Dataset) (
 
 	go func() {
 		for _, data := range datasets {
-			// randomly sleep 0 or 1 second
-			if rand.Intn(2) > 0 {
-				time.Sleep(time.Second)
-			}
 			inp <- data
 		}
 		close(inp)


### PR DESCRIPTION
It slows down the tests for no apparent reason, and if there's a reason - it makes me wonder how is this deterministic?

@aviaoh this random sleep was introduced in commit 46d80c8117d5631434bfdb588a0772ba1848b937 . This commit only has the comment "Update test_utils.go". The comment in the code is just as confusing. Care to elaborate about why we need it?

Also - is there are reason that this function is exposed if its only used for tests?