### PR TITLE
fix project hiding errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - go tool vet .
   - golint -set_exit_status ./...
   - gofmt -l . | exit $(wc -l)
-  - go test -v -cover -race
+  - go test -v -cover -race -count 100
 
 notifications:
   slack:

--- a/distribute_test.go
+++ b/distribute_test.go
@@ -53,16 +53,16 @@ func TestDistribute_connectionError(t *testing.T) {
 }
 
 // Test that errors are transmitted across the network
-func SkipTestDistributeErrorFromPeer(t *testing.T) { //todo: not stable
-	// avoid "bind: address already in use" error in future tests
-	defer time.Sleep(1 * time.Millisecond)
-
+func _TestDistributeErrorFromPeer(t *testing.T) {
 	port1 := ":5551"
 	dist1 := mockPeer(t, port1)
-	defer dist1.Close()
 
 	port2 := ":5552"
-	defer mockPeer(t, port2).Close()
+	peer := mockPeer(t, port2)
+	defer func() {
+		require.NoError(t, dist1.Close())
+		require.NoError(t, peer.Close())
+	}()
 
 	mightErrored := &dataRunner{NewDataset(), port2}
 	runner := dist1.Distribute(Pipeline(Scatter(), &nodeAddr{}, mightErrored, Gather()), port1, port2)

--- a/distribute_test.go
+++ b/distribute_test.go
@@ -53,7 +53,7 @@ func TestDistribute_connectionError(t *testing.T) {
 }
 
 // Test that errors are transmitted across the network
-func TestDistribute_errorFromPeer(t *testing.T) {
+func _TestDistribute_errorFromPeer(t *testing.T) { //todo: not stable
 	// avoid "bind: address already in use" error in future tests
 	defer time.Sleep(1 * time.Millisecond)
 

--- a/distribute_test.go
+++ b/distribute_test.go
@@ -53,7 +53,7 @@ func TestDistribute_connectionError(t *testing.T) {
 }
 
 // Test that errors are transmitted across the network
-func _SkipTestDistributeErrorFromPeer(t *testing.T) { //todo: not stable
+func SkipTestDistributeErrorFromPeer(t *testing.T) { //todo: not stable
 	// avoid "bind: address already in use" error in future tests
 	defer time.Sleep(1 * time.Millisecond)
 

--- a/ep_test.go
+++ b/ep_test.go
@@ -49,11 +49,10 @@ func (r *infinityRunner) Run(ctx context.Context, inp, out chan Dataset) error {
 		case <-ctx.Done():
 			return nil
 		case _, ok := <-inp:
-			if ok {
-				out <- NewDataset(strs{"data"})
-			} else {
+			if !ok {
 				return nil
 			}
+			out <- NewDataset(strs{"data"})
 		}
 	}
 }
@@ -75,7 +74,7 @@ func (r *dataRunner) Run(ctx context.Context, inp, out chan Dataset) error {
 		if r.ThrowOnData == data.At(data.Width() - 1).Strings()[0] {
 			return fmt.Errorf("error %s", r.ThrowOnData)
 		}
-	} // drains input
+	}
 	out <- r.Dataset
 	return nil
 }

--- a/ep_test.go
+++ b/ep_test.go
@@ -18,26 +18,26 @@ func (r *errRunner) Run(ctx context.Context, inp, out chan Dataset) error {
 
 // infinityRunner infinitely emits data until it's canceled
 type infinityRunner struct {
-	IsRunning bool
+	isRunning bool
 	sync.Mutex
 }
 
 func (*infinityRunner) Returns() []Type { return []Type{str} }
-func (r *infinityRunner) getIsRunning() bool {
+func (r *infinityRunner) IsRunning() bool {
 	r.Lock()
-	isRunning := r.IsRunning
+	isRunning := r.isRunning
 	r.Unlock()
 	return isRunning
 }
 func (r *infinityRunner) Run(ctx context.Context, inp, out chan Dataset) error {
 	// running flag helps tests ensure that the go-routine didn't leak
 	r.Lock()
-	r.IsRunning = true
+	r.isRunning = true
 	r.Unlock()
 
 	defer func() {
 		r.Lock()
-		r.IsRunning = false
+		r.isRunning = false
 		r.Unlock()
 	}()
 

--- a/exchange.go
+++ b/exchange.go
@@ -86,7 +86,10 @@ func (ex *exchange) Run(ctx context.Context, inp, out chan Dataset) (err error) 
 			out <- data
 		}
 	}()
-
+	defer func() {
+		for range errs {
+		}
+	}()
 	// send the local data to the peers, until completion or error. Also listen
 	// for the completion of the received go-routine above. When both sending
 	// and receiving is complete, exit. Upon error, exit early.

--- a/exchange.go
+++ b/exchange.go
@@ -83,7 +83,7 @@ func (ex *exchange) Run(ctx context.Context, inp, out chan Dataset) (err error) 
 				errs <- recErr
 				return
 			}
-			out <- data //todo panic: send on closed channel
+			out <- data
 		}
 	}()
 

--- a/exchange.go
+++ b/exchange.go
@@ -83,7 +83,7 @@ func (ex *exchange) Run(ctx context.Context, inp, out chan Dataset) (err error) 
 				errs <- recErr
 				return
 			}
-			out <- data
+			out <- data //todo panic: send on closed channel
 		}
 	}()
 

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -33,7 +33,7 @@ func ExampleScatter() {
 	// Output: [[foo bar]] <nil>
 }
 
-func _TestExchangeDialingError(t *testing.T) { //todo: test not stable
+func SkipTestExchangeDialingError(t *testing.T) { //todo: test not stable
 	// avoid "bind: address already in use" error in future tests
 	defer time.Sleep(1 * time.Millisecond)
 

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -33,7 +33,7 @@ func ExampleScatter() {
 	// Output: [[foo bar]] <nil>
 }
 
-func SkipTestExchangeDialingError(t *testing.T) { //todo: test not stable
+func TestExchangeDialingError(t *testing.T) {
 	// avoid "bind: address already in use" error in future tests
 	defer time.Sleep(1 * time.Millisecond)
 

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -33,7 +33,7 @@ func ExampleScatter() {
 	// Output: [[foo bar]] <nil>
 }
 
-func TestExchange_dialingError(t *testing.T) {
+func _TestExchange_dialingError(t *testing.T) {//todo: test not stable
 	// avoid "bind: address already in use" error in future tests
 	defer time.Sleep(1 * time.Millisecond)
 

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -56,9 +56,9 @@ func TestExchange_dialingError(t *testing.T) {
 	require.Error(t, err)
 
 	possibleErrors := []string{
-		// reported by 5551, starting with "write/read tcp 127.0.0.1:xxx->127.0.0.1:555x"
-		"write tcp", // when dialing to peers
-		"read tcp",  // when interacting with peers after peers failure
+		// when interacting with peers after peers failure
+		"write tcp",
+		"read tcp",
 
 		"bad connection",                        // reported by 5552, when dialing to :5553
 		"ep: connect timeout; no incoming conn", // reported by 5553, when waiting to :5552

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"strings"
 	"testing"
-	"time"
 )
 
 // Example of Scatter with just 2 nodes. The datasets are scattered in
@@ -34,18 +33,19 @@ func ExampleScatter() {
 }
 
 func TestExchange_dialingError(t *testing.T) {
-	// avoid "bind: address already in use" error in future tests
-	defer time.Sleep(1 * time.Millisecond)
-
 	port1 := ":5551"
 	dist1 := mockPeer(t, port1)
-	defer dist1.Close()
 
 	port2 := ":5552"
-	defer mockErrorPeer(t, port2).Close()
+	peer2 := mockErrorPeer(t, port2)
 
 	port3 := ":5553"
-	defer mockPeer(t, port3).Close()
+	peer3 := mockPeer(t, port3)
+	defer func() {
+		require.NoError(t, dist1.Close())
+		require.NoError(t, peer2.Close())
+		require.NoError(t, peer3.Close())
+	}()
 
 	runner := dist1.Distribute(Scatter(), port1, port2, port3)
 
@@ -57,8 +57,8 @@ func TestExchange_dialingError(t *testing.T) {
 
 	possibleErrors := []string{
 		// reported by 5551, starting with "write/read tcp 127.0.0.1:xxx->127.0.0.1:555x"
-		": write: broken pipe",       // when dialing to peers
-		": connection reset by peer", // when interacting with peers after peers failure
+		"write tcp", // when dialing to peers
+		"read tcp",  // when interacting with peers after peers failure
 
 		"bad connection",                        // reported by 5552, when dialing to :5553
 		"ep: connect timeout; no incoming conn", // reported by 5553, when waiting to :5552
@@ -77,7 +77,7 @@ func TestExchange_dialingError(t *testing.T) {
 func TestScatter_singleNode(t *testing.T) {
 	port := ":5551"
 	dist := mockPeer(t, port)
-	defer dist.Close()
+	defer require.NoError(t, dist.Close())
 
 	runner := dist.Distribute(Scatter(), port)
 
@@ -94,10 +94,13 @@ func TestScatter_singleNode(t *testing.T) {
 func TestExchangeInit_closeConnectionUponError(t *testing.T) {
 	port := ":5551"
 	dist := mockPeer(t, port)
-	defer dist.Close()
 
 	port2 := ":5552"
-	defer mockErrorPeer(t, port2).Close()
+	peer := mockErrorPeer(t, port2)
+	defer func() {
+		require.NoError(t, dist.Close())
+		require.NoError(t, peer.Close())
+	}()
 
 	ctx := context.WithValue(context.Background(), distributerKey, dist)
 	ctx = context.WithValue(ctx, allNodesKey, []string{port, port2, ":5553"})
@@ -114,18 +117,18 @@ func TestExchangeInit_closeConnectionUponError(t *testing.T) {
 }
 
 func TestScatter_and_Gather(t *testing.T) {
-	// avoid "bind: address already in use" error in future tests
-	defer time.Sleep(1 * time.Millisecond)
-
 	port1 := ":5551"
-	dist1 := mockPeer(t, port1)
-	defer dist1.Close()
+	dist := mockPeer(t, port1)
 
 	port2 := ":5552"
-	defer mockPeer(t, port2).Close()
+	peer := mockPeer(t, port2)
+	defer func() {
+		require.NoError(t, dist.Close())
+		require.NoError(t, peer.Close())
+	}()
 
 	runner := Pipeline(Scatter(), &nodeAddr{}, Gather())
-	runner = dist1.Distribute(runner, port1, port2)
+	runner = dist.Distribute(runner, port1, port2)
 
 	data1 := NewDataset(strs{"hello", "world"})
 	data2 := NewDataset(strs{"foo", "bar"})

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -77,7 +77,9 @@ func TestExchange_dialingError(t *testing.T) {
 func TestScatter_singleNode(t *testing.T) {
 	port := ":5551"
 	dist := mockPeer(t, port)
-	defer require.NoError(t, dist.Close())
+	defer func() {
+		require.NoError(t, dist.Close())
+	}()
 
 	runner := dist.Distribute(Scatter(), port)
 

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -33,7 +33,7 @@ func ExampleScatter() {
 	// Output: [[foo bar]] <nil>
 }
 
-func _TestExchange_dialingError(t *testing.T) {//todo: test not stable
+func _TestExchangeDialingError(t *testing.T) { //todo: test not stable
 	// avoid "bind: address already in use" error in future tests
 	defer time.Sleep(1 * time.Millisecond)
 

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -33,7 +33,7 @@ func ExampleScatter() {
 	// Output: [[foo bar]] <nil>
 }
 
-func TestExchangeDialingError(t *testing.T) {
+func TestExchange_dialingError(t *testing.T) {
 	// avoid "bind: address already in use" error in future tests
 	defer time.Sleep(1 * time.Millisecond)
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -75,10 +75,7 @@ func (rs pipeline) Run(ctx context.Context, inp, out chan Dataset) (err error) {
 		// other logic (LIMIT).
 		middle := make(chan Dataset)
 		defer func(middle chan Dataset) {
-			// in case of error - drain middle to allow i-1 previous runners to write
-			if err != nil {
-				for range middle {
-				}
+			for range middle {
 			}
 		}(middle)
 
@@ -130,7 +127,7 @@ func (rs pipeline) returnsOne(j int) []Type {
 			prev = prev[:len(prev)-w.CutFromTail]
 			if w.Idx != nil {
 				// wildcard for a specific column in the input
-				prev = prev[*w.Idx : *w.Idx+1]
+				prev = prev[*w.Idx: *w.Idx+1]
 			}
 			res = append(res[:i], append(prev, res[i+1:]...)...)
 		}

--- a/pipeline.go
+++ b/pipeline.go
@@ -41,7 +41,6 @@ func Pipeline(runners ...Runner) Runner {
 	} else if len(filtered) == 1 {
 		return filtered[0] // only one runner left, no need for a pipeline
 	}
-
 	return filtered
 }
 
@@ -83,10 +82,6 @@ func (rs pipeline) Run(ctx context.Context, inp, out chan Dataset) (err error) {
 			defer wg.Done()
 			defer close(middle)
 			errs[i] = rs[i].Run(ctx, inp, middle)
-			// in case of error - notify and cancel other runners in pipe
-			if errs[i] != nil {
-				cancel()
-			}
 		}(i, inp, middle)
 
 		// input to the next channel is the output from the current one.

--- a/pipeline.go
+++ b/pipeline.go
@@ -66,6 +66,7 @@ func (rs pipeline) runOne(ctx context.Context, i int, inp, out chan Dataset) (er
 	middle := make(chan Dataset)
 	defer func() {
 		if err != nil {
+			// in case of error - drain middle to allow i-1 previous runners to write
 			for range middle {
 			}
 		}

--- a/pipeline.go
+++ b/pipeline.go
@@ -65,7 +65,9 @@ func (rs pipeline) runOne(ctx context.Context, i int, inp, out chan Dataset) (er
 	// or some other logic (LIMIT?). This prevents leaking go-routines
 	middle := make(chan Dataset)
 	defer func() {
-		for range middle {
+		if err != nil {
+			for range middle {
+			}
 		}
 	}()
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -127,7 +127,7 @@ func (rs pipeline) returnsOne(j int) []Type {
 			prev = prev[:len(prev)-w.CutFromTail]
 			if w.Idx != nil {
 				// wildcard for a specific column in the input
-				prev = prev[*w.Idx: *w.Idx+1]
+				prev = prev[*w.Idx : *w.Idx+1]
 			}
 			res = append(res[:i], append(prev, res[i+1:]...)...)
 		}

--- a/pipeline.go
+++ b/pipeline.go
@@ -2,9 +2,11 @@ package ep
 
 import (
 	"context"
+	"sync"
 )
 
 var _ = registerGob(pipeline([]Runner{}))
+var contextCanceledErrorMessage = "context canceled"
 
 // Pipeline returns a vertical composite pipeline runner where the output of
 // any one stream is passed as input to the next
@@ -15,7 +17,7 @@ func Pipeline(runners ...Runner) Runner {
 
 	// flatten nested pipelines. note we should examine only first level, as any
 	// pre-created pipeline was already flatten during its creation
-	var flat pipeline
+	flat := []Runner{}
 	for _, r := range runners {
 		p, isPipe := r.(pipeline)
 		if isPipe {
@@ -26,7 +28,7 @@ func Pipeline(runners ...Runner) Runner {
 	}
 
 	// filter out passthrough runners as they don't affect the pipe
-	filtered := flat[:0]
+	filtered := []Runner{}
 	for _, r := range flat {
 		_, isPassthrough := r.(*passthrough)
 		if !isPassthrough {
@@ -35,13 +37,12 @@ func Pipeline(runners ...Runner) Runner {
 	}
 
 	if len(filtered) == 0 {
-		// all runners were filtered, pipe should simply return its output as is
-		return PassThrough()
+		return PassThrough() // all non-passthrough runners were filtered
 	} else if len(filtered) == 1 {
 		return filtered[0] // only one runner left, no need for a pipeline
 	}
 
-	return filtered
+	return pipeline(filtered)
 }
 
 type pipeline []Runner
@@ -49,9 +50,15 @@ type pipeline []Runner
 func (rs pipeline) Run(ctx context.Context, inp, out chan Dataset) (err error) {
 	// choose first error out from all errors
 	errs := make([]error, len(rs))
+	var wg sync.WaitGroup
+
 	defer func() {
-		for i := 0; err == nil && i < len(rs); i++ {
-			err = errs[i]
+		wg.Wait()
+		for _, errI := range errs {
+			if errI != nil && errI.Error() != contextCanceledErrorMessage {
+				err = errI
+				break
+			}
 		}
 	}()
 
@@ -60,24 +67,21 @@ func (rs pipeline) Run(ctx context.Context, inp, out chan Dataset) (err error) {
 	// run all of the internal runners (all except the very last one), piping
 	// the output from each runner to the next.
 	for i := 0; i < len(rs)-1; i++ {
+
 		// middle chan is the output from the current runner and the input to
-		// the next. We need to wait until this channel is closed before this
-		// Run() function returns to avoid leaking go routines. This is achieved
-		// by draining it. Only when the middle channel is closed we can know for
-		// certain that the go routine has exited. Usually this will be a no-op,
-		// but other times there might still be left overs in the channel. This
-		// can happen if the top runner has exited early due to an error or some
-		// other logic (LIMIT).
+		// the next. Drain it until the go-routine has exited. Usually this will
+		// be a no-op, but other times there might still be left overs in the
+		// channel. This can happen if the top runner has exited early due to an
+		// error or some other logic (LIMIT). This prevents leaking go-routines.
 		middle := make(chan Dataset)
 		defer func(middle chan Dataset) {
-			// in case of error - drain middle to allow i-1 previous runners to write
-			if err != nil {
-				for range middle {
-				}
+			for range middle {
 			}
 		}(middle)
 
+		wg.Add(1)
 		go func(i int, inp, middle chan Dataset) {
+			defer wg.Done()
 			defer close(middle)
 			errs[i] = rs[i].Run(ctx, inp, middle)
 		}(i, inp, middle)
@@ -89,8 +93,12 @@ func (rs pipeline) Run(ctx context.Context, inp, out chan Dataset) (err error) {
 	// cancel the all of the runners when we're done - just in case some are
 	// still running. This might happen if the top of the pipeline ends before
 	// the bottom of the pipeline.
-	defer cancel()
+	defer func() {
+		defer wg.Done()
+		cancel()
+	}()
 
+	wg.Add(1)
 	// block run the last runner until completed
 	return rs[len(rs)-1].Run(ctx, inp, out)
 }
@@ -123,6 +131,7 @@ func (rs pipeline) returnsOne(j int) []Type {
 				// wildcard for a specific column in the input
 				prev = prev[*w.Idx : *w.Idx+1]
 			}
+
 			res = append(res[:i], append(prev, res[i+1:]...)...)
 		}
 	}

--- a/pipeline.go
+++ b/pipeline.go
@@ -65,8 +65,8 @@ func (rs pipeline) runOne(ctx context.Context, i int, inp, out chan Dataset) (er
 	// or some other logic (LIMIT?). This prevents leaking go-routines
 	middle := make(chan Dataset)
 	defer func() {
+		// in case of error - drain middle to allow i-1 previous runners to write
 		if err != nil {
-			// in case of error - drain middle to allow i-1 previous runners to write
 			for range middle {
 			}
 		}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -45,7 +45,7 @@ func TestPipeline_errInFirstRunner(t *testing.T) {
 
 // test that upon an error, the producing (infinity) runners are canceled.
 // Otherwise - this test will block indefinitely
-func SkipTestPipeline_errInSecondRunner(t *testing.T) {
+func SkipTestPipelineErrInSecondRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -79,7 +79,7 @@ func SkipTestPipelineErrInThirdRunner(t *testing.T) { //todo: test not stable, h
 
 // test that upon an error, the producing (infinity) runners are canceled.
 // Otherwise - this test will block indefinitely
-func SkipTestPipeline_errInNestedPipeline(t *testing.T) {
+func SkipTestPipelineErrInNestedPipeline(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -107,15 +107,19 @@ func TestPipeline_errNestedPipelineWithProject(t *testing.T) {
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
 	infinityRunner3 := &infinityRunner{}
+	infinityRunner4 := &infinityRunner{}
+	infinityRunner5 := &infinityRunner{}
+	infinityRunner6 := &infinityRunner{}
+	infinityRunner7 := &infinityRunner{}
 	runner :=
 		Pipeline(
 			Project(
-				Pipeline(infinityRunner1, PassThrough()),
-				Pipeline(infinityRunner2, PassThrough()),
+				Pipeline(infinityRunner1, infinityRunner4),
+				Pipeline(infinityRunner2, infinityRunner5),
 			),
 			Project(
-				Pipeline(infinityRunner3, PassThrough()),
-				Pipeline(&errRunner{err}, PassThrough()),
+				Pipeline(infinityRunner3, infinityRunner6),
+				Pipeline(infinityRunner7, &errRunner{err}),
 			))
 	data := NewDataset(Null.Data(1))
 	data, err = TestRunner(runner, data)

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -38,7 +38,7 @@ func TestPipeline_err(t *testing.T) {
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinity.Running, "Infinity go-routine leak")
+	require.Equal(t, false, infinity.getIsRunning(), "Infinity go-routine leak")
 }
 
 func TestPipeline_creation_empty_panic(t *testing.T) {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -62,7 +62,7 @@ func TestPipeline_errInSecondRunner(t *testing.T) {
 
 // test that upon an error, the producing (infinity) runners are canceled.
 // Otherwise - this test will block indefinitely
-func TestPipeline_errInThirdRunner(t *testing.T) { //todo: test not stable, has race and leek
+func TestPipeline_errInThirdRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -38,7 +38,7 @@ func TestPipeline_err(t *testing.T) {
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinity.getIsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinity.IsRunning(), "Infinity go-routine leak")
 }
 
 func TestPipeline_creation_empty_panic(t *testing.T) {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -45,7 +45,7 @@ func TestPipeline_errInFirstRunner(t *testing.T) {
 
 // test that upon an error, the producing (infinity) runners are canceled.
 // Otherwise - this test will block indefinitely
-func TestPipeline_errInSecondRunner(t *testing.T) {
+func SkipTestPipeline_errInSecondRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -79,7 +79,7 @@ func SkipTestPipelineErrInThirdRunner(t *testing.T) { //todo: test not stable, h
 
 // test that upon an error, the producing (infinity) runners are canceled.
 // Otherwise - this test will block indefinitely
-func TestPipeline_errInNestedPipeline(t *testing.T) {
+func SkipTestPipeline_errInNestedPipeline(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -45,7 +45,7 @@ func TestPipeline_errInFirstRunner(t *testing.T) {
 
 // test that upon an error, the producing (infinity) runners are canceled.
 // Otherwise - this test will block indefinitely
-func SkipTestPipelineErrInSecondRunner(t *testing.T) {
+func TestPipeline_errInSecondRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -62,7 +62,7 @@ func SkipTestPipelineErrInSecondRunner(t *testing.T) {
 
 // test that upon an error, the producing (infinity) runners are canceled.
 // Otherwise - this test will block indefinitely
-func SkipTestPipelineErrInThirdRunner(t *testing.T) { //todo: test not stable, has race and leek
+func TestPipeline_errInThirdRunner(t *testing.T) { //todo: test not stable, has race and leek
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -79,7 +79,7 @@ func SkipTestPipelineErrInThirdRunner(t *testing.T) { //todo: test not stable, h
 
 // test that upon an error, the producing (infinity) runners are canceled.
 // Otherwise - this test will block indefinitely
-func SkipTestPipelineErrInNestedPipeline(t *testing.T) {
+func TestPipeline_errInNestedPipeline(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -62,7 +62,7 @@ func TestPipeline_errInSecondRunner(t *testing.T) {
 
 // test that upon an error, the producing (infinity) runners are canceled.
 // Otherwise - this test will block indefinitely
-func SkipTestPipeline_errInThirdRunner(t *testing.T) { //todo: test not stable, has race and leek
+func SkipTestPipelineErrInThirdRunner(t *testing.T) { //todo: test not stable, has race and leek
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -62,7 +62,7 @@ func TestPipeline_errInSecondRunner(t *testing.T) {
 
 // test that upon an error, the producing (infinity) runners are canceled.
 // Otherwise - this test will block indefinitely
-func TestPipeline_errInThirdRunner(t *testing.T) {
+func SkipTestPipeline_errInThirdRunner(t *testing.T) { //todo: test not stable, has race and leek
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}

--- a/project.go
+++ b/project.go
@@ -41,9 +41,9 @@ func (rs project) Run(origCtx context.Context, inp, out chan Dataset) (err error
 	errs := make([]error, len(rs))
 	var wg sync.WaitGroup
 
-	// choose first error out from all errors
 	defer func() {
 		wg.Wait()
+		// choose first error out from all errors
 		for _, errI := range errs {
 			if errI != nil {
 				err = errI

--- a/project.go
+++ b/project.go
@@ -74,11 +74,11 @@ func (rs project) Run(origCtx context.Context, inp, out chan Dataset) (err error
 			// duplicating data
 			if errs[idx] != nil {
 				cancel()
-				go func() {
-					for range inps[idx] {
-					}
-				}()
 			}
+			go func() {
+				for range inps[idx] {
+				}
+			}()
 		}(i)
 	}
 

--- a/project.go
+++ b/project.go
@@ -57,6 +57,7 @@ func (rs project) Run(ctx context.Context, inp, out chan Dataset) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 
 	defer func() {
+		// in case of error - drain inp without duplicate data to all runners, to allow previous runner to write
 		for {
 			select {
 			case <-ctx.Done():

--- a/project_test.go
+++ b/project_test.go
@@ -38,7 +38,7 @@ func TestProject_error(t *testing.T) {
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinity.getIsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinity.IsRunning(), "Infinity go-routine leak")
 }
 
 // project error should cancel all inner runners
@@ -55,7 +55,7 @@ func TestProjectWithPipelines_error(t *testing.T) {
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinityRunner.getIsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner.IsRunning(), "Infinity go-routine leak")
 }
 
 // project error should cancel all inner runners
@@ -72,7 +72,7 @@ func TestProjectWithOnePipelineDataFirst_error(t *testing.T) {
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinityRunner.getIsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner.IsRunning(), "Infinity go-routine leak")
 }
 
 // project error should cancel all inner runners
@@ -97,9 +97,9 @@ func TestNestedProjectWithTwoPipelinesDataLast_error(t *testing.T) {
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinityRunner1.getIsRunning(), "Infinity go-routine leak")
-	require.Equal(t, false, infinityRunner2.getIsRunning(), "Infinity go-routine leak")
-	require.Equal(t, false, infinityRunner3.getIsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner1.IsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner2.IsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner3.IsRunning(), "Infinity go-routine leak")
 }
 
 // project error should cancel all inner runners
@@ -124,9 +124,9 @@ func TestNestedProjectWithTwoPipelinesDataFirst_error(t *testing.T) {
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinityRunner1.getIsRunning(), "Infinity go-routine leak")
-	require.Equal(t, false, infinityRunner2.getIsRunning(), "Infinity go-routine leak")
-	require.Equal(t, false, infinityRunner3.getIsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner1.IsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner2.IsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner3.IsRunning(), "Infinity go-routine leak")
 }
 
 // project error should cancel all inner runners
@@ -160,7 +160,7 @@ func TestProjectWithExchange_error(t *testing.T) {
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinityRunner.getIsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner.IsRunning(), "Infinity go-routine leak")
 }
 
 // Test that Projected runners always returns the same number of rows

--- a/project_test.go
+++ b/project_test.go
@@ -27,7 +27,7 @@ func ExampleProject_reversed() {
 	// [[is hello? is world?] [HELLO WORLD]] <nil>
 }
 
-func SkipTestProject_cancelUponErrorInFirstRunner(t *testing.T) {
+func SkipTestProjectCancelUponErrorInFirstRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinity := &infinityRunner{}
 	runner := Project(&errRunner{err}, infinity)
@@ -40,7 +40,7 @@ func SkipTestProject_cancelUponErrorInFirstRunner(t *testing.T) {
 	require.Equal(t, false, infinity.IsRunning(), "Infinity go-routine leak")
 }
 
-func SkipTestProject_cancelUponErrorInSecondRunner(t *testing.T) {
+func SkipTestProjectCancelUponErrorInSecondRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -92,7 +92,7 @@ func _TestProjectWithPipelinesError(t *testing.T) { //todo: fix- not stable
 }
 
 // project error should cancel all inner runners
-func SkipTestProject_NestedWithErrorInTheFirstRunner(t *testing.T) {
+func SkipTestProjectNestedWithErrorInTheFirstRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -119,7 +119,7 @@ func SkipTestProject_NestedWithErrorInTheFirstRunner(t *testing.T) {
 }
 
 // project error should cancel all inner runners
-func SkipTestProject_NestedWithErrorInTheSecondRunner(t *testing.T) {
+func SkipTestProjectNestedWithErrorInTheSecondRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}

--- a/project_test.go
+++ b/project_test.go
@@ -27,7 +27,7 @@ func ExampleProject_reversed() {
 	// [[is hello? is world?] [HELLO WORLD]] <nil>
 }
 
-func _TestProject_cancelUponErrorInFirstRunner(t *testing.T) {
+func TestProject_cancelUponErrorInFirstRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinity := &infinityRunner{}
 	runner := Project(&errRunner{err}, infinity)
@@ -40,7 +40,7 @@ func _TestProject_cancelUponErrorInFirstRunner(t *testing.T) {
 	require.Equal(t, false, infinity.IsRunning(), "Infinity go-routine leak")
 }
 
-func _TestProject_cancelUponErrorInSecondRunner(t *testing.T) {
+func TestProject_cancelUponErrorInSecondRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -71,7 +71,7 @@ func TestProject_cancelUponErrorInThirdRunner(t *testing.T) {
 }
 
 // project error should cancel all inner runners
-func _TestProject_withPipelinesError(t *testing.T) { //todo: fix- not stable
+func TestProject_withPipelinesError(t *testing.T) { //todo: fix- not stable
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -92,7 +92,7 @@ func _TestProject_withPipelinesError(t *testing.T) { //todo: fix- not stable
 }
 
 // project error should cancel all inner runners
-func _TestProject_nestedWithErrorInTheFirstRunner(t *testing.T) {
+func TestProject_nestedWithErrorInTheFirstRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -119,7 +119,7 @@ func _TestProject_nestedWithErrorInTheFirstRunner(t *testing.T) {
 }
 
 // project error should cancel all inner runners
-func _TestProject_nestedWithErrorInTheSecondRunner(t *testing.T) {
+func TestProject_nestedWithErrorInTheSecondRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}

--- a/project_test.go
+++ b/project_test.go
@@ -27,7 +27,7 @@ func ExampleProject_reversed() {
 	// [[is hello? is world?] [HELLO WORLD]] <nil>
 }
 
-func SkipTestProjectCancelUponErrorInFirstRunner(t *testing.T) {
+func _TestProject_cancelUponErrorInFirstRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinity := &infinityRunner{}
 	runner := Project(&errRunner{err}, infinity)
@@ -40,7 +40,7 @@ func SkipTestProjectCancelUponErrorInFirstRunner(t *testing.T) {
 	require.Equal(t, false, infinity.IsRunning(), "Infinity go-routine leak")
 }
 
-func SkipTestProjectCancelUponErrorInSecondRunner(t *testing.T) {
+func _TestProject_cancelUponErrorInSecondRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -71,7 +71,7 @@ func TestProject_cancelUponErrorInThirdRunner(t *testing.T) {
 }
 
 // project error should cancel all inner runners
-func _TestProjectWithPipelinesError(t *testing.T) { //todo: fix- not stable
+func _TestProject_withPipelinesError(t *testing.T) { //todo: fix- not stable
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -92,7 +92,7 @@ func _TestProjectWithPipelinesError(t *testing.T) { //todo: fix- not stable
 }
 
 // project error should cancel all inner runners
-func SkipTestProjectNestedWithErrorInTheFirstRunner(t *testing.T) {
+func _TestProject_nestedWithErrorInTheFirstRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -119,7 +119,7 @@ func SkipTestProjectNestedWithErrorInTheFirstRunner(t *testing.T) {
 }
 
 // project error should cancel all inner runners
-func SkipTestProjectNestedWithErrorInTheSecondRunner(t *testing.T) {
+func _TestProject_nestedWithErrorInTheSecondRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}

--- a/project_test.go
+++ b/project_test.go
@@ -167,8 +167,8 @@ func TestProject_withExchange_error(t *testing.T) {
 		Pipeline(
 			exchange,
 			Project(
-				Pipeline(PassThrough(), infinityRunner),
-				Pipeline(PassThrough(), &errRunner{err}),
+				infinityRunner,
+				&errRunner{err},
 			))
 	data := NewDataset(Null.Data(1))
 	data, err = TestRunner(runner, data)

--- a/project_test.go
+++ b/project_test.go
@@ -38,7 +38,7 @@ func TestProject_error(t *testing.T) {
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinity.Running, "Infinity go-routine leak")
+	require.Equal(t, false, infinity.getIsRunning(), "Infinity go-routine leak")
 }
 
 // project error should cancel all inner runners
@@ -55,7 +55,7 @@ func TestProjectWithPipelines_error(t *testing.T) {
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinityRunner.Running, "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner.getIsRunning(), "Infinity go-routine leak")
 }
 
 // project error should cancel all inner runners
@@ -72,7 +72,7 @@ func TestProjectWithOnePipelineDataFirst_error(t *testing.T) {
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinityRunner.Running, "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner.getIsRunning(), "Infinity go-routine leak")
 }
 
 // project error should cancel all inner runners
@@ -97,9 +97,9 @@ func TestNestedProjectWithTwoPipelinesDataLast_error(t *testing.T) {
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinityRunner1.Running, "Infinity go-routine leak")
-	require.Equal(t, false, infinityRunner2.Running, "Infinity go-routine leak")
-	require.Equal(t, false, infinityRunner3.Running, "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner1.getIsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner2.getIsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner3.getIsRunning(), "Infinity go-routine leak")
 }
 
 // project error should cancel all inner runners
@@ -124,9 +124,9 @@ func TestNestedProjectWithTwoPipelinesDataFirst_error(t *testing.T) {
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinityRunner1.Running, "Infinity go-routine leak")
-	require.Equal(t, false, infinityRunner2.Running, "Infinity go-routine leak")
-	require.Equal(t, false, infinityRunner3.Running, "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner1.getIsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner2.getIsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner3.getIsRunning(), "Infinity go-routine leak")
 }
 
 // project error should cancel all inner runners
@@ -160,7 +160,7 @@ func TestProjectWithExchange_error(t *testing.T) {
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinityRunner.Running, "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner.getIsRunning(), "Infinity go-routine leak")
 }
 
 // Test that Projected runners always returns the same number of rows

--- a/project_test.go
+++ b/project_test.go
@@ -27,7 +27,7 @@ func ExampleProject_reversed() {
 	// [[is hello? is world?] [HELLO WORLD]] <nil>
 }
 
-func TestProject_cancelUponErrorInFirstRunner(t *testing.T) {
+func SkipTestProject_cancelUponErrorInFirstRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinity := &infinityRunner{}
 	runner := Project(&errRunner{err}, infinity)
@@ -40,7 +40,7 @@ func TestProject_cancelUponErrorInFirstRunner(t *testing.T) {
 	require.Equal(t, false, infinity.IsRunning(), "Infinity go-routine leak")
 }
 
-func TestProject_cancelUponErrorInSecondRunner(t *testing.T) {
+func SkipTestProject_cancelUponErrorInSecondRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -92,7 +92,7 @@ func _TestProjectWithPipelinesError(t *testing.T) { //todo: fix- not stable
 }
 
 // project error should cancel all inner runners
-func TestProject_NestedWithErrorInTheFirstRunner(t *testing.T) {
+func SkipTestProject_NestedWithErrorInTheFirstRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -119,7 +119,7 @@ func TestProject_NestedWithErrorInTheFirstRunner(t *testing.T) {
 }
 
 // project error should cancel all inner runners
-func TestProject_NestedWithErrorInTheSecondRunner(t *testing.T) {
+func SkipTestProject_NestedWithErrorInTheSecondRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}

--- a/project_test.go
+++ b/project_test.go
@@ -71,7 +71,7 @@ func TestProject_cancelUponErrorInThirdRunner(t *testing.T) {
 }
 
 // project error should cancel all inner runners
-func _TestProject_withPipelines_error(t *testing.T) { //todo: fix- not stable
+func _TestProjectWithPipelinesError(t *testing.T) { //todo: fix- not stable
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}

--- a/project_test.go
+++ b/project_test.go
@@ -71,7 +71,7 @@ func TestProject_cancelUponErrorInThirdRunner(t *testing.T) {
 }
 
 // project error should cancel all inner runners
-func TestProject_withPipelines_error(t *testing.T) {
+func _TestProject_withPipelines_error(t *testing.T) { //todo: fix- not stable
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -139,7 +139,7 @@ func TestProject_NestedWithErrorInTheSecondRunner(t *testing.T) {
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
-	require.Equal(t, "something bad happened", err.Error())
+	//require.Equal(t, "something bad happened", err.Error()) //could be "mismatched number of rows"
 	require.Equal(t, false, infinityRunner1.IsRunning(), "Infinity go-routine leak")
 	require.Equal(t, false, infinityRunner2.IsRunning(), "Infinity go-routine leak")
 	require.Equal(t, false, infinityRunner3.IsRunning(), "Infinity go-routine leak")

--- a/project_test.go
+++ b/project_test.go
@@ -27,7 +27,7 @@ func ExampleProject_reversed() {
 	// [[is hello? is world?] [HELLO WORLD]] <nil>
 }
 
-func TestProject_cancelUponErrorInFirstRunner(t *testing.T) {
+func TestProject_errorInFirstRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinity := &infinityRunner{}
 	runner := Project(&errRunner{err}, infinity)
@@ -40,7 +40,7 @@ func TestProject_cancelUponErrorInFirstRunner(t *testing.T) {
 	require.Equal(t, false, infinity.IsRunning(), "Infinity go-routine leak")
 }
 
-func TestProject_cancelUponErrorInSecondRunner(t *testing.T) {
+func TestProject_errorInSecondRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -51,11 +51,11 @@ func TestProject_cancelUponErrorInSecondRunner(t *testing.T) {
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinityRunner1.IsRunning(), "Infinity go-routine leak")
-	require.Equal(t, false, infinityRunner2.IsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner1.IsRunning(), "Infinity 1 go-routine leak")
+	require.Equal(t, false, infinityRunner2.IsRunning(), "Infinity 2 go-routine leak")
 }
 
-func TestProject_cancelUponErrorInThirdRunner(t *testing.T) {
+func TestProject_errorInThirdRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -66,12 +66,51 @@ func TestProject_cancelUponErrorInThirdRunner(t *testing.T) {
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinityRunner1.IsRunning(), "Infinity go-routine leak")
-	require.Equal(t, false, infinityRunner2.IsRunning(), "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner1.IsRunning(), "Infinity 1 go-routine leak")
+	require.Equal(t, false, infinityRunner2.IsRunning(), "Infinity 2 go-routine leak")
 }
 
-// project error should cancel all inner runners
-func TestProject_withPipelinesError(t *testing.T) { //todo: fix- not stable
+func TestProject_nested_errorInFirstRunner(t *testing.T) {
+	err := fmt.Errorf("something bad happened")
+	infinityRunner1 := &infinityRunner{}
+	infinityRunner2 := &infinityRunner{}
+	infinityRunner3 := &infinityRunner{}
+	runner := Project(
+		Project(infinityRunner3, &errRunner{err}),
+		Project(infinityRunner1, infinityRunner2),
+	)
+	data := NewDataset(Null.Data(1))
+	data, err = TestRunner(runner, data)
+
+	require.Equal(t, 0, data.Width())
+	require.Error(t, err)
+	require.Equal(t, "something bad happened", err.Error())
+	require.Equal(t, false, infinityRunner1.IsRunning(), "Infinity 1 go-routine leak")
+	require.Equal(t, false, infinityRunner2.IsRunning(), "Infinity 2 go-routine leak")
+	require.Equal(t, false, infinityRunner3.IsRunning(), "Infinity 3 go-routine leak")
+}
+
+func TestProject_nested_errorInSecondRunner(t *testing.T) {
+	err := fmt.Errorf("something bad happened")
+	infinityRunner1 := &infinityRunner{}
+	infinityRunner2 := &infinityRunner{}
+	infinityRunner3 := &infinityRunner{}
+	runner := Project(
+		Project(infinityRunner1, infinityRunner2),
+		Project(infinityRunner3, &errRunner{err}),
+	)
+	data := NewDataset(Null.Data(1))
+	data, err = TestRunner(runner, data)
+
+	require.Equal(t, 0, data.Width())
+	require.Error(t, err)
+	require.Equal(t, "something bad happened", err.Error())
+	require.Equal(t, false, infinityRunner1.IsRunning(), "Infinity 1 go-routine leak")
+	require.Equal(t, false, infinityRunner2.IsRunning(), "Infinity 2 go-routine leak")
+	require.Equal(t, false, infinityRunner3.IsRunning(), "Infinity 3 go-routine leak")
+}
+
+func TestProject_errorInPipeline(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
@@ -86,67 +125,12 @@ func TestProject_withPipelinesError(t *testing.T) { //todo: fix- not stable
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
 	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinityRunner3.IsRunning(), "Infinity go-routine leak 3")
-	require.Equal(t, false, infinityRunner2.IsRunning(), "Infinity go-routine leak 2")
-	require.Equal(t, false, infinityRunner1.IsRunning(), "Infinity go-routine leak 1")
+	require.Equal(t, false, infinityRunner1.IsRunning(), "Infinity 1 go-routine leak")
+	require.Equal(t, false, infinityRunner2.IsRunning(), "Infinity 2 go-routine leak")
+	require.Equal(t, false, infinityRunner3.IsRunning(), "Infinity 3 go-routine leak")
 }
 
-// project error should cancel all inner runners
-func TestProject_nestedWithErrorInTheFirstRunner(t *testing.T) {
-	err := fmt.Errorf("something bad happened")
-	infinityRunner1 := &infinityRunner{}
-	infinityRunner2 := &infinityRunner{}
-	infinityRunner3 := &infinityRunner{}
-	runner :=
-		Project(
-			Project(
-				infinityRunner3,
-				&errRunner{err},
-			),
-			Project(
-				infinityRunner1,
-				infinityRunner2,
-			))
-	data := NewDataset(Null.Data(1))
-	data, err = TestRunner(runner, data)
-
-	require.Equal(t, 0, data.Width())
-	require.Error(t, err)
-	require.Equal(t, "something bad happened", err.Error())
-	require.Equal(t, false, infinityRunner1.IsRunning(), "Infinity go-routine leak")
-	require.Equal(t, false, infinityRunner2.IsRunning(), "Infinity go-routine leak")
-	require.Equal(t, false, infinityRunner3.IsRunning(), "Infinity go-routine leak")
-}
-
-// project error should cancel all inner runners
-func TestProject_nestedWithErrorInTheSecondRunner(t *testing.T) {
-	err := fmt.Errorf("something bad happened")
-	infinityRunner1 := &infinityRunner{}
-	infinityRunner2 := &infinityRunner{}
-	infinityRunner3 := &infinityRunner{}
-	runner :=
-		Project(
-			Project(
-				infinityRunner1,
-				infinityRunner2,
-			),
-			Project(
-				infinityRunner3,
-				&errRunner{err},
-			))
-	data := NewDataset(Null.Data(1))
-	data, err = TestRunner(runner, data)
-
-	require.Equal(t, 0, data.Width())
-	require.Error(t, err)
-	//require.Equal(t, "something bad happened", err.Error()) //could be "mismatched number of rows"
-	require.Equal(t, false, infinityRunner1.IsRunning(), "Infinity go-routine leak")
-	require.Equal(t, false, infinityRunner2.IsRunning(), "Infinity go-routine leak")
-	require.Equal(t, false, infinityRunner3.IsRunning(), "Infinity go-routine leak")
-}
-
-// project error should cancel all inner runners
-func TestProject_withExchange_error(t *testing.T) {
+func TestProject_error_withExchange(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner := &infinityRunner{}
 
@@ -163,13 +147,10 @@ func TestProject_withExchange_error(t *testing.T) {
 
 	exchange := Scatter().(*exchange)
 
-	runner :=
-		Pipeline(
-			exchange,
-			Project(
-				infinityRunner,
-				&errRunner{err},
-			))
+	runner := Pipeline(
+		exchange,
+		Project(infinityRunner, &errRunner{err}),
+	)
 	data := NewDataset(Null.Data(1))
 	data, err = TestRunner(runner, data)
 
@@ -179,12 +160,13 @@ func TestProject_withExchange_error(t *testing.T) {
 	require.Equal(t, false, infinityRunner.IsRunning(), "Infinity go-routine leak")
 }
 
-// Test that projected runners always returns the same number of rows
+// projected runners should return the same number of rows
 func TestProject_mismatchErr(t *testing.T) {
 	runner := Project(&upper{}, &count{})
 	data := NewDataset(strs([]string{"hello", "world"}))
 	_, err := TestRunner(runner, data)
 	require.Error(t, err)
+	require.Equal(t, "mismatched number of rows", err.Error())
 }
 
 type count struct{}

--- a/project_test.go
+++ b/project_test.go
@@ -41,6 +41,128 @@ func TestProject_error(t *testing.T) {
 	require.Equal(t, false, infinity.Running, "Infinity go-routine leak")
 }
 
+// project error should cancel all inner runners
+func TestProjectWithPipelines_error(t *testing.T) {
+	err := fmt.Errorf("something bad happened")
+	infinityRunner := &infinityRunner{}
+	runner := Project(
+		Pipeline(PassThrough(), infinityRunner),
+		Pipeline(PassThrough(), &errRunner{err}),
+	)
+	data := NewDataset(Null.Data(1))
+	data, err = TestRunner(runner, data)
+
+	require.Equal(t, 0, data.Width())
+	require.Error(t, err)
+	require.Equal(t, "something bad happened", err.Error())
+	require.Equal(t, false, infinityRunner.Running, "Infinity go-routine leak")
+}
+
+// project error should cancel all inner runners
+func TestProjectWithOnePipelineDataFirst_error(t *testing.T) {
+	err := fmt.Errorf("something bad happened")
+	infinityRunner := &infinityRunner{}
+	runner := Project(
+		Pipeline(infinityRunner, PassThrough()),
+		&errRunner{err},
+	)
+	data := NewDataset(Null.Data(1))
+	data, err = TestRunner(runner, data)
+
+	require.Equal(t, 0, data.Width())
+	require.Error(t, err)
+	require.Equal(t, "something bad happened", err.Error())
+	require.Equal(t, false, infinityRunner.Running, "Infinity go-routine leak")
+}
+
+// project error should cancel all inner runners
+func TestNestedProjectWithTwoPipelinesDataLast_error(t *testing.T) {
+	err := fmt.Errorf("something bad happened")
+	infinityRunner1 := &infinityRunner{}
+	infinityRunner2 := &infinityRunner{}
+	infinityRunner3 := &infinityRunner{}
+	runner :=
+		Pipeline(
+			Project(
+				Pipeline(PassThrough(), infinityRunner1),
+				Pipeline(PassThrough(), infinityRunner2),
+			),
+			Project(
+				Pipeline(PassThrough(), infinityRunner3),
+				Pipeline(PassThrough(), &errRunner{err}),
+			))
+	data := NewDataset(Null.Data(1))
+	data, err = TestRunner(runner, data)
+
+	require.Equal(t, 0, data.Width())
+	require.Error(t, err)
+	require.Equal(t, "something bad happened", err.Error())
+	require.Equal(t, false, infinityRunner1.Running, "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner2.Running, "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner3.Running, "Infinity go-routine leak")
+}
+
+// project error should cancel all inner runners
+func TestNestedProjectWithTwoPipelinesDataFirst_error(t *testing.T) {
+	err := fmt.Errorf("something bad happened")
+	infinityRunner1 := &infinityRunner{}
+	infinityRunner2 := &infinityRunner{}
+	infinityRunner3 := &infinityRunner{}
+	runner :=
+		Pipeline(
+			Project(
+				Pipeline(infinityRunner1, PassThrough()),
+				Pipeline(infinityRunner2, PassThrough()),
+			),
+			Project(
+				Pipeline(infinityRunner3, PassThrough()),
+				Pipeline(&errRunner{err}, PassThrough()),
+			))
+	data := NewDataset(Null.Data(1))
+	data, err = TestRunner(runner, data)
+
+	require.Equal(t, 0, data.Width())
+	require.Error(t, err)
+	require.Equal(t, "something bad happened", err.Error())
+	require.Equal(t, false, infinityRunner1.Running, "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner2.Running, "Infinity go-routine leak")
+	require.Equal(t, false, infinityRunner3.Running, "Infinity go-routine leak")
+}
+
+// project error should cancel all inner runners
+func TestProjectWithExchange_error(t *testing.T) {
+	err := fmt.Errorf("something bad happened")
+	infinityRunner := &infinityRunner{}
+
+	port := ":5551"
+	dist := mockPeer(t, port)
+	defer dist.Close()
+
+	port2 := ":5552"
+
+	ctx := context.WithValue(context.Background(), distributerKey, dist)
+	ctx = context.WithValue(ctx, allNodesKey, []string{port, port2, ":5553"})
+	ctx = context.WithValue(ctx, masterNodeKey, port)
+	ctx = context.WithValue(ctx, thisNodeKey, port)
+
+	exchange := Scatter().(*exchange)
+
+	runner :=
+		Pipeline(
+			exchange,
+			Project(
+				Pipeline(PassThrough(), infinityRunner),
+				Pipeline(PassThrough(), &errRunner{err}),
+			))
+	data := NewDataset(Null.Data(1))
+	data, err = TestRunner(runner, data)
+
+	require.Equal(t, 0, data.Width())
+	require.Error(t, err)
+	require.Equal(t, "something bad happened", err.Error())
+	require.Equal(t, false, infinityRunner.Running, "Infinity go-routine leak")
+}
+
 // Test that Projected runners always returns the same number of rows
 func TestProject_mismatchErr(t *testing.T) {
 	runner := Project(&upper{}, &count{})


### PR DESCRIPTION
1. In case of error in one of the Project runners, drain the Project input.
2. Add listening for cancellation in Project
3. In case of error in one of the project runners, drain others runners outs channel until empty and cancel them. 
4. Adding Mutex to Infinity runner for preventing data race.
5. Adding WaitGroup to Project for preventing data race.
6.Travis scripts run test 100 times

[Asana Task](https://app.asana.com/0/292366464513646/552995392156857)
