### PR TITLE
fix example data race by using log to print err + upgrade to go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,8 @@ branches:
   only:
     - master
 
-env:
-  - GIMME_OS=linux GIMME_ARCH=amd64
-
 go:
-  - 1.10
+  - "1.10"
 
 install:
   - go get -t -v ./... # all deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
     - master
 
 go:
-  - 1.9.x
+  - 1.10.x
 
 install:
   - go get -t -v ./... # all deps
@@ -16,7 +16,7 @@ script:
   - go tool vet .
   - golint -set_exit_status ./...
   - gofmt -l . | exit $(wc -l)
-  - go test -v ./... -cover -race
+  - go test -v -cover -race
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
     - master
 
 go:
-  - 1.10.x
+  - 1.10
 
 install:
   - go get -t -v ./... # all deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ branches:
   only:
     - master
 
+env:
+  - GIMME_OS=linux GIMME_ARCH=amd64
+
 go:
   - 1.10
 

--- a/distribute.go
+++ b/distribute.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"sync"
 	"time"
+	"log"
 )
 
 // MagicNumber used by the built-in Distributer to prefix all of its connections
@@ -177,7 +178,7 @@ func (d *distributer) Serve(conn net.Conn) error {
 		dec := gob.NewDecoder(conn)
 		err := dec.Decode(r)
 		if err != nil {
-			fmt.Println("ep: distributer error", err)
+			log.Println("ep: distributer error", err)
 			return err
 		}
 
@@ -203,14 +204,14 @@ func (d *distributer) Serve(conn net.Conn) error {
 		enc := gob.NewEncoder(conn)
 		err = enc.Encode(&req{err})
 		if err != nil {
-			fmt.Println("ep: runner error", err)
+			log.Println("ep: runner error", err)
 			return err
 		}
 	} else {
 		defer conn.Close()
 
 		err := fmt.Errorf("unrecognized connection type: %s", typee)
-		fmt.Println("ep: " + err.Error())
+		log.Println("ep: " + err.Error())
 		return err
 	}
 

--- a/distribute.go
+++ b/distribute.go
@@ -5,10 +5,10 @@ import (
 	"encoding/gob"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"sync"
 	"time"
-	"log"
 )
 
 // MagicNumber used by the built-in Distributer to prefix all of its connections

--- a/distribute_test.go
+++ b/distribute_test.go
@@ -48,7 +48,7 @@ func TestDistribute_connectionError(t *testing.T) {
 	data, err := TestRunner(runner, NewDataset())
 
 	require.Error(t, err)
-	require.Equal(t, "dial tcp :5000: getsockopt: connection refused", err.Error())
+	require.Equal(t, "dial tcp :5000: connect: connection refused", err.Error())
 	require.Nil(t, data)
 }
 

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -57,8 +57,8 @@ func TestExchange_dialingError(t *testing.T) {
 
 	possibleErrors := []string{
 		// reported by 5551, starting with "write/read tcp 127.0.0.1:xxx->127.0.0.1:555x"
-		": write: broken pipe",             // when dialing to peers
-		": read: connection reset by peer", // when reading from peers after peers failure
+		": write: broken pipe",       // when dialing to peers
+		": connection reset by peer", // when reading from peers after peers failure
 
 		"bad connection",                        // reported by 5552, when dialing to :5553
 		"ep: connect timeout; no incoming conn", // reported by 5553, when waiting to :5552

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -58,7 +58,7 @@ func TestExchange_dialingError(t *testing.T) {
 	possibleErrors := []string{
 		// reported by 5551, starting with "write/read tcp 127.0.0.1:xxx->127.0.0.1:555x"
 		": write: broken pipe",       // when dialing to peers
-		": connection reset by peer", // when reading from peers after peers failure
+		": connection reset by peer", // when interacting with peers after peers failure
 
 		"bad connection",                        // reported by 5552, when dialing to :5553
 		"ep: connect timeout; no incoming conn", // reported by 5553, when waiting to :5552


### PR DESCRIPTION
- upgrade to go 1.10
- fix example data race by using log to print err:
```
WARNING: DATA RACE
Read at 0x000000a971b0 by goroutine 85:
  fmt.Println()
...
Previous write at 0x000000a971b0 by main goroutine:
  testing.runExample.func2()
```