### PR TITLE
First experimental benchmark test for pipelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - go tool vet .
   - golint -set_exit_status ./...
   - gofmt -l . | exit $(wc -l)
-  - go test -v -cover -race
+  - go test -v -cover -race -benchmem -bench .
 
 notifications:
   slack:

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -154,6 +154,26 @@ func TestPipeline_Returns_wildcardMinusTail(t *testing.T) {
 	require.Equal(t, "upper", GetAlias(types[0]))
 }
 
+// Measures the number of datasets (ops) per second going through a pipeline
+// composed of 3 pass-throughs.
+func BenchmarkPipeline(b *testing.B) {
+	data := NewDataset(strs([]string{"hello", "world", "foo", "bar"}))
+	inp := make(chan Dataset)
+	out := make(chan Dataset)
+	defer close(inp)
+	defer close(out)
+
+	r := pipeline{PassThrough(), PassThrough(), PassThrough()}
+	go r.Run(context.Background(), inp, out)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// run a single dataset through the pipeline
+		inp <- data
+		<-out
+	}
+}
+
 type tailCutter struct {
 	CutFromTail int
 }

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -155,7 +155,9 @@ func TestPipeline_Returns_wildcardMinusTail(t *testing.T) {
 }
 
 // Measures the number of datasets (ops) per second going through a pipeline
-// composed of 3 pass-throughs.
+// composed of 3 pass-throughs. At the time of writing, it was evident that
+// performance is not impacted by the size of the datasets (sensible, given
+// the implementation details).
 func BenchmarkPipeline(b *testing.B) {
 	data := NewDataset(strs([]string{"hello", "world", "foo", "bar"}))
 	inp := make(chan Dataset)


### PR DESCRIPTION
I plan on updating the pipeline code to be flat, instead of recursive - like you did in project. But first, I wanted to have a benchmark to compare against. This is mostly here for discussion about how we do benchmark tests. In this example, I wanted to measure the runtime/allocations per dataset. 