### PR TITLE
Refactor the pipeline to not use recursion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ script:
   - go tool vet .
   - golint -set_exit_status ./...
   - gofmt -l . | exit $(wc -l)
-  - go test -v -cover -race -benchmem -bench .
+  - go test -cover -race ./...
+  - go test -v -run nothing -bench=. ./... # benchmark
 
 notifications:
   slack:

--- a/exchange.go
+++ b/exchange.go
@@ -117,8 +117,13 @@ func (ex *exchange) Run(ctx context.Context, inp, out chan Dataset) (err error) 
 			err = ex.Send(data)
 		case err = <-errs:
 			rcvDone = true // errors (or nil) from the receive go-routine
-		case <-ctx.Done():
-			err = ctx.Err() // context timeout or cancel
+		case <-ctx.Done(): // context timeout or cancel
+			err = ctx.Err()
+			// as all other runners - in case of cancellation, runner should stop
+			// without effecting final error
+			if err == context.Canceled {
+				return nil
+			}
 		}
 	}
 	return err

--- a/pipeline.go
+++ b/pipeline.go
@@ -50,11 +50,8 @@ func (rs pipeline) Run(ctx context.Context, inp, out chan Dataset) (err error) {
 	// choose first error out from all errors
 	errs := make([]error, len(rs))
 	defer func() {
-		for _, errI := range errs {
-			if errI != nil {
-				err = errI
-				break
-			}
+		for i := 0; err == nil && i < len(rs); i++ {
+			err = errs[i]
 		}
 	}()
 
@@ -63,7 +60,6 @@ func (rs pipeline) Run(ctx context.Context, inp, out chan Dataset) (err error) {
 	// run all of the internal runners (all except the very last one), piping
 	// the output from each runner to the next.
 	for i := 0; i < len(rs)-1; i++ {
-
 		// middle chan is the output from the current runner and the input to
 		// the next. We need to wait until this channel is closed before this
 		// Run() function returns to avoid leaking go routines. This is achieved
@@ -124,7 +120,6 @@ func (rs pipeline) returnsOne(j int) []Type {
 				// wildcard for a specific column in the input
 				prev = prev[*w.Idx : *w.Idx+1]
 			}
-
 			res = append(res[:i], append(prev, res[i+1:]...)...)
 		}
 	}

--- a/pipeline.go
+++ b/pipeline.go
@@ -15,7 +15,7 @@ func Pipeline(runners ...Runner) Runner {
 
 	// flatten nested pipelines. note we should examine only first level, as any
 	// pre-created pipeline was already flatten during its creation
-	flat := []Runner{}
+	var flat pipeline
 	for _, r := range runners {
 		p, isPipe := r.(pipeline)
 		if isPipe {
@@ -26,7 +26,7 @@ func Pipeline(runners ...Runner) Runner {
 	}
 
 	// filter out passthrough runners as they don't affect the pipe
-	filtered := []Runner{}
+	filtered := flat[:0]
 	for _, r := range flat {
 		_, isPassthrough := r.(*passthrough)
 		if !isPassthrough {
@@ -35,12 +35,13 @@ func Pipeline(runners ...Runner) Runner {
 	}
 
 	if len(filtered) == 0 {
-		return PassThrough() // all non-passthrough runners were filtered
+		// all runners were filtered, pipe should simply return its output as is
+		return PassThrough()
 	} else if len(filtered) == 1 {
 		return filtered[0] // only one runner left, no need for a pipeline
 	}
 
-	return pipeline(filtered)
+	return filtered
 }
 
 type pipeline []Runner


### PR DESCRIPTION
To keep the Pipeline implementation consistent in design to the new Project implementation. Also refactored the Pipeline construction code to remove the repetitive test for passthroughs. Benchmarks were unaffected by this change.