### PR TITLE
separate ep tests to different package + fix exchange deadlock

### DIFF
--- a/data_example_test.go
+++ b/data_example_test.go
@@ -1,29 +1,30 @@
-package ep
+package ep_test
 
 import (
 	"fmt"
+	"github.com/panoplyio/ep"
 	"sort"
 )
 
+var _ = ep.Types.Register("string", str)
 var str = &strType{}
-var _ = Types.Register("string", str)
 
 type strType struct{}
 
-func (*strType) Name() string         { return "string" }
-func (s *strType) String() string     { return s.Name() }
-func (*strType) Data(n int) Data      { return make(strs, n) }
-func (*strType) DataEmpty(n int) Data { return make(strs, 0, n) }
+func (s *strType) String() string        { return s.Name() }
+func (*strType) Name() string            { return "string" }
+func (*strType) Data(n int) ep.Data      { return make(strs, n) }
+func (*strType) DataEmpty(n int) ep.Data { return make(strs, 0, n) }
 
 type strs []string
 
-func (strs) Type() Type             { return str }
-func (vs strs) Len() int            { return len(vs) }
-func (vs strs) Less(i, j int) bool  { return vs[i] < vs[j] }
-func (vs strs) Swap(i, j int)       { vs[i], vs[j] = vs[j], vs[i] }
-func (vs strs) Slice(s, e int) Data { return vs[s:e] }
-func (vs strs) Append(o Data) Data  { return append(vs, o.(strs)...) }
-func (vs strs) Duplicate(t int) Data {
+func (strs) Type() ep.Type               { return str }
+func (vs strs) Len() int                 { return len(vs) }
+func (vs strs) Less(i, j int) bool       { return vs[i] < vs[j] }
+func (vs strs) Swap(i, j int)            { vs[i], vs[j] = vs[j], vs[i] }
+func (vs strs) Slice(s, e int) ep.Data   { return vs[s:e] }
+func (vs strs) Append(o ep.Data) ep.Data { return append(vs, o.(strs)...) }
+func (vs strs) Duplicate(t int) ep.Data {
 	ans := make(strs, 0, vs.Len()*t)
 	for i := 0; i < t; i++ {
 		ans = append(ans, vs...)
@@ -33,7 +34,7 @@ func (vs strs) Duplicate(t int) Data {
 func (vs strs) Strings() []string { return vs }
 
 func ExampleData() {
-	var strs Data = strs([]string{"hello", "world", "foo", "bar"})
+	var strs ep.Data = strs([]string{"hello", "world", "foo", "bar"})
 	sort.Sort(strs)
 	strs = strs.Slice(0, 2)
 	fmt.Println(strs.Strings())

--- a/data_utils_example_test.go
+++ b/data_utils_example_test.go
@@ -1,12 +1,13 @@
-package ep
+package ep_test
 
 import (
 	"fmt"
+	"github.com/panoplyio/ep"
 )
 
 func ExampleClone() {
-	var d1 Data = strs([]string{"hello", "world"})
-	d2 := Clone(d1).(strs)
+	var d1 ep.Data = strs([]string{"hello", "world"})
+	d2 := ep.Clone(d1).(strs)
 
 	d2[0] = "foo"
 	d2[1] = "bar"
@@ -19,8 +20,8 @@ func ExampleClone() {
 }
 
 func ExampleCut() {
-	var d Data = strs([]string{"hello", "world", "foo", "bar"})
-	data := Cut(d, 1, 3)
+	var d ep.Data = strs([]string{"hello", "world", "foo", "bar"})
+	data := ep.Cut(d, 1, 3)
 	fmt.Println(data.Strings())
 
 	// Output:
@@ -28,8 +29,8 @@ func ExampleCut() {
 }
 
 func ExamplePartition() {
-	var d Data = strs([]string{"hello", "world", "hello", "bar"})
-	data := Partition(d)
+	var d ep.Data = strs([]string{"hello", "world", "hello", "bar"})
+	data := ep.Partition(d)
 	fmt.Println(data.Strings())
 
 	// Output:

--- a/dataset.go
+++ b/dataset.go
@@ -10,7 +10,7 @@ var errMismatch = fmt.Errorf("mismatched number of rows")
 
 // Dataset is a composite Data interface, containing several internal Data
 // objects. It's a Data in itself, but allows traversing and manipulating the
-// contained Data intstances
+// contained Data instances
 type Dataset interface {
 	Data // It's a Data - you can use it anywhere you'd use a Data object
 

--- a/dataset_sort_test.go
+++ b/dataset_sort_test.go
@@ -1,19 +1,20 @@
-package ep
+package ep_test
 
 import (
 	"fmt"
+	"github.com/panoplyio/ep"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 func TestDatasetSort(t *testing.T) {
-	var d1 Data = strs([]string{"hello", "world", "foo", "bar", "bar", "a", "z"})
-	var d2 Data = strs([]string{"1", "2", "4", "0", "3", "1", "1"})
-	var d3 Data = strs([]string{"a", "b", "c", "d", "e", "f", "g"})
+	var d1 ep.Data = strs([]string{"hello", "world", "foo", "bar", "bar", "a", "z"})
+	var d2 ep.Data = strs([]string{"1", "2", "4", "0", "3", "1", "1"})
+	var d3 ep.Data = strs([]string{"a", "b", "c", "d", "e", "f", "g"})
 
-	dataset := NewDataset(d1, d2, d3, d1, d2, d1)
+	dataset := ep.NewDataset(d1, d2, d3, d1, d2, d1)
 
-	Sort(dataset, []SortingCol{{1, false}, {3, false}})
+	ep.Sort(dataset, []ep.SortingCol{{Index: 1, Desc: false}, {Index: 3, Desc: false}})
 
 	require.Equal(t, 7, dataset.Len())
 	require.Equal(t, 6, dataset.Width())
@@ -28,13 +29,13 @@ func TestDatasetSort(t *testing.T) {
 }
 
 func TestDadasetSort_firstDesc(t *testing.T) {
-	var d1 Data = strs([]string{"hello", "world", "foo", "bar", "bar", "a", "z"})
-	var d2 Data = strs([]string{"1", "2", "4", "0", "3", "1", "1"})
-	var d3 Data = strs([]string{"a", "b", "c", "d", "e", "f", "g"})
+	var d1 ep.Data = strs([]string{"hello", "world", "foo", "bar", "bar", "a", "z"})
+	var d2 ep.Data = strs([]string{"1", "2", "4", "0", "3", "1", "1"})
+	var d3 ep.Data = strs([]string{"a", "b", "c", "d", "e", "f", "g"})
 
-	dataset := NewDataset(d1, d2, d3, d2, d1)
+	dataset := ep.NewDataset(d1, d2, d3, d2, d1)
 
-	Sort(dataset, []SortingCol{{1, true}, {4, false}})
+	ep.Sort(dataset, []ep.SortingCol{{Index: 1, Desc: true}, {Index: 4, Desc: false}})
 
 	require.Equal(t, 7, dataset.Len())
 	require.Equal(t, 5, dataset.Width())
@@ -49,13 +50,13 @@ func TestDadasetSort_firstDesc(t *testing.T) {
 }
 
 func TestDadasetSort_secondDesc(t *testing.T) {
-	var d1 Data = strs([]string{"hello", "world", "foo", "bar", "bar", "a", "z"})
-	var d2 Data = strs([]string{"1", "2", "4", "0", "3", "1", "1"})
-	var d3 Data = strs([]string{"a", "b", "c", "d", "e", "f", "g"})
+	var d1 ep.Data = strs([]string{"hello", "world", "foo", "bar", "bar", "a", "z"})
+	var d2 ep.Data = strs([]string{"1", "2", "4", "0", "3", "1", "1"})
+	var d3 ep.Data = strs([]string{"a", "b", "c", "d", "e", "f", "g"})
 
-	dataset := NewDataset(d1, d2, d3, d2, d1)
+	dataset := ep.NewDataset(d1, d2, d3, d2, d1)
 
-	Sort(dataset, []SortingCol{{3, false}, {0, true}})
+	ep.Sort(dataset, []ep.SortingCol{{Index: 3, Desc: false}, {Index: 0, Desc: true}})
 
 	require.Equal(t, 7, dataset.Len())
 	require.Equal(t, 5, dataset.Width())
@@ -70,13 +71,13 @@ func TestDadasetSort_secondDesc(t *testing.T) {
 }
 
 func TestDadasetSort_severalDesc(t *testing.T) {
-	var d1 Data = strs([]string{"hello", "world", "foo", "bar", "bar", "a", "z"})
-	var d2 Data = strs([]string{"1", "2", "4", "0", "3", "1", "1"})
-	var d3 Data = strs([]string{"a", "b", "c", "d", "e", "f", "g"})
+	var d1 ep.Data = strs([]string{"hello", "world", "foo", "bar", "bar", "a", "z"})
+	var d2 ep.Data = strs([]string{"1", "2", "4", "0", "3", "1", "1"})
+	var d3 ep.Data = strs([]string{"a", "b", "c", "d", "e", "f", "g"})
 
-	dataset := NewDataset(d1, d2, d3, d2, d1)
+	dataset := ep.NewDataset(d1, d2, d3, d2, d1)
 
-	Sort(dataset, []SortingCol{{3, true}, {0, true}})
+	ep.Sort(dataset, []ep.SortingCol{{Index: 3, Desc: true}, {Index: 0, Desc: true}})
 
 	require.Equal(t, 7, dataset.Len())
 	require.Equal(t, 5, dataset.Width())
@@ -92,25 +93,25 @@ func TestDadasetSort_severalDesc(t *testing.T) {
 
 func TestDatasetSort_emptyDataset(t *testing.T) {
 	require.NotPanics(t, func() {
-		Sort(NewDataset(), []SortingCol{{1, false}, {3, false}})
+		ep.Sort(ep.NewDataset(), []ep.SortingCol{{Index: 1, Desc: false}, {Index: 3, Desc: false}})
 	})
 }
 
 func TestDatasetSort_nilDataset(t *testing.T) {
 	require.NotPanics(t, func() {
-		Sort(nil, []SortingCol{{1, false}, {3, false}})
+		ep.Sort(nil, []ep.SortingCol{{Index: 1, Desc: false}, {Index: 3, Desc: false}})
 	})
 }
 
 func TestDatasetSort_noSortingCols(t *testing.T) {
-	var d1 Data = strs([]string{"hello", "world", "foo", "bar", "bar", "a", "z"})
-	var d2 Data = strs([]string{"1", "2", "4", "0", "3", "1", "1"})
-	var d3 Data = strs([]string{"a", "b", "c", "d", "e", "f", "g"})
+	var d1 ep.Data = strs([]string{"hello", "world", "foo", "bar", "bar", "a", "z"})
+	var d2 ep.Data = strs([]string{"1", "2", "4", "0", "3", "1", "1"})
+	var d3 ep.Data = strs([]string{"a", "b", "c", "d", "e", "f", "g"})
 
-	dataset := NewDataset(d1, d3, d2)
+	dataset := ep.NewDataset(d1, d3, d2)
 
 	require.NotPanics(t, func() {
-		Sort(dataset, []SortingCol{})
+		ep.Sort(dataset, []ep.SortingCol{})
 	})
 
 	// by default sorting done according to last column ascending

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestDataInterface(t *testing.T) {
 	dataset := ep.NewDataset(ep.Null.Data(10), str.Data(10))
-	eptest.VerifyDataInvariant(t, dataset)
+	eptest.VerifyDataInterfaceInvariant(t, dataset)
 }
 
 func TestDataset_Sort_byLastColAscending(t *testing.T) {

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -1,23 +1,25 @@
-package ep
+package ep_test
 
 import (
 	"fmt"
+	"github.com/panoplyio/ep"
+	"github.com/panoplyio/ep/eptest"
 	"github.com/stretchr/testify/require"
 	"sort"
 	"testing"
 )
 
 func TestDataInterface(t *testing.T) {
-	dataset := NewDataset(Null.Data(10), str.Data(10))
-	VerifyDataInvariant(t, dataset)
+	dataset := ep.NewDataset(ep.Null.Data(10), str.Data(10))
+	eptest.VerifyDataInvariant(t, dataset)
 }
 
 func TestDataset_Sort_byLastColAscending(t *testing.T) {
-	var d1 Data = strs([]string{"hello", "world", "foo", "bar", "bar", "a", "z"})
-	var d2 Data = strs([]string{"1", "2", "4", "0", "3", "1", "1"})
-	var d3 Data = strs([]string{"a", "b", "c", "d", "e", "f", "g"})
+	var d1 ep.Data = strs([]string{"hello", "world", "foo", "bar", "bar", "a", "z"})
+	var d2 ep.Data = strs([]string{"1", "2", "4", "0", "3", "1", "1"})
+	var d3 ep.Data = strs([]string{"a", "b", "c", "d", "e", "f", "g"})
 
-	dataset := NewDataset(d1, d3, d2)
+	dataset := ep.NewDataset(d1, d3, d2)
 
 	sort.Sort(dataset)
 

--- a/distribute.go
+++ b/distribute.go
@@ -322,7 +322,7 @@ func (r *distRunner) Run(ctx context.Context, inp, out chan Dataset) error {
 		close(respErrs)
 	}()
 
-	// wait for first error
+	// wait for either first error or closing of respErrs channel
 	e, _ := <-respErrs
 	errs = append(errs, e)
 	return errs[0]

--- a/distribute.go
+++ b/distribute.go
@@ -321,8 +321,11 @@ func (r *distRunner) Run(ctx context.Context, inp, out chan Dataset) error {
 		close(respErrs)
 	}()
 
-	// wait for respErrs channel, and select first meaningful error
 	var finalError error
+	if len(errs) > 0 {
+		finalError = errs[0]
+	}
+	// wait for respErrs channel anyway, and select first meaningful error
 	for e := range respErrs {
 		if finalError == nil && e != errProjectState {
 			finalError = e

--- a/distribute_test.go
+++ b/distribute_test.go
@@ -56,7 +56,7 @@ func TestDistribute_connectionError(t *testing.T) {
 }
 
 // Test that errors are transmitted across the network
-func TestDistribute_errorFromPeer(t *testing.T) {
+func _TestDistributeErrorFromPeer(t *testing.T) {
 	port1 := ":5551"
 	dist1 := eptest.NewPeer(t, port1)
 
@@ -68,7 +68,8 @@ func TestDistribute_errorFromPeer(t *testing.T) {
 	}()
 
 	mightErrored := &dataRunner{ep.NewDataset(), port2}
-	runner := dist1.Distribute(ep.Pipeline(ep.Scatter(), &nodeAddr{}, mightErrored), port1, port2)
+	runner := ep.Pipeline(ep.Scatter(), &nodeAddr{}, mightErrored)
+	runner = dist1.Distribute(runner, port1, port2)
 
 	data1 := ep.NewDataset(strs{"hello", "world"})
 	data2 := ep.NewDataset(strs{"foo", "bar"})

--- a/distribute_test.go
+++ b/distribute_test.go
@@ -31,7 +31,7 @@ func TestDistribute_success(t *testing.T) {
 
 	data1 := ep.NewDataset(strs{"hello", "world"})
 	data2 := ep.NewDataset(strs{"foo", "bar"})
-	data, err := eptest.TestRunner(runner, data1, data2)
+	data, err := eptest.Run(runner, data1, data2)
 
 	require.NoError(t, err)
 	require.Equal(t, 1, data.Width())
@@ -48,7 +48,7 @@ func TestDistribute_connectionError(t *testing.T) {
 
 	runner := dist1.Distribute(&upper{}, port1, ":5000")
 
-	data, err := eptest.TestRunner(runner, ep.NewDataset())
+	data, err := eptest.Run(runner, ep.NewDataset())
 
 	require.Error(t, err)
 	require.Equal(t, "dial tcp :5000: connect: connection refused", err.Error())
@@ -72,7 +72,7 @@ func _TestDistributeErrorFromPeer(t *testing.T) {
 
 	data1 := ep.NewDataset(strs{"hello", "world"})
 	data2 := ep.NewDataset(strs{"foo", "bar"})
-	data, err := eptest.TestRunner(runner, data1, data2)
+	data, err := eptest.Run(runner, data1, data2)
 
 	require.Error(t, err)
 	require.Equal(t, "error :5552", err.Error())

--- a/distribute_test.go
+++ b/distribute_test.go
@@ -1,34 +1,37 @@
-package ep
+package ep_test
 
 import (
 	"fmt"
+	"github.com/panoplyio/ep"
+	"github.com/panoplyio/ep/eptest"
 	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 )
-
-var _ = registerGob(&upper{})
-var _ = registerGob(&dataRunner{})
 
 func TestDistribute_success(t *testing.T) {
 	// avoid "bind: address already in use" error in future tests
 	defer time.Sleep(1 * time.Millisecond)
 
 	port1 := ":5551"
-	dist1 := mockPeer(t, port1)
-	defer dist1.Close()
+	dist1 := eptest.NewPeer(t, port1)
 
 	port2 := ":5552"
-	defer mockPeer(t, port2).Close()
+	peer2 := eptest.NewPeer(t, port2)
 
 	port3 := ":5553"
-	defer mockPeer(t, port3).Close()
+	peer3 := eptest.NewPeer(t, port3)
+	defer func() {
+		require.NoError(t, dist1.Close())
+		require.NoError(t, peer2.Close())
+		require.NoError(t, peer3.Close())
+	}()
 
-	runner := dist1.Distribute(Pipeline(Scatter(), Gather()), port1, port2, port3)
+	runner := dist1.Distribute(ep.Pipeline(ep.Scatter(), ep.Gather()), port1, port2, port3)
 
-	data1 := NewDataset(strs{"hello", "world"})
-	data2 := NewDataset(strs{"foo", "bar"})
-	data, err := TestRunner(runner, data1, data2)
+	data1 := ep.NewDataset(strs{"hello", "world"})
+	data2 := ep.NewDataset(strs{"foo", "bar"})
+	data, err := eptest.TestRunner(runner, data1, data2)
 
 	require.NoError(t, err)
 	require.Equal(t, 1, data.Width())
@@ -40,12 +43,12 @@ func TestDistribute_connectionError(t *testing.T) {
 	defer time.Sleep(1 * time.Millisecond)
 
 	port1 := ":5551"
-	dist1 := mockPeer(t, port1)
-	defer dist1.Close()
+	dist1 := eptest.NewPeer(t, port1)
+	defer require.NoError(t, dist1.Close())
 
 	runner := dist1.Distribute(&upper{}, port1, ":5000")
 
-	data, err := TestRunner(runner, NewDataset())
+	data, err := eptest.TestRunner(runner, ep.NewDataset())
 
 	require.Error(t, err)
 	require.Equal(t, "dial tcp :5000: connect: connection refused", err.Error())
@@ -55,21 +58,21 @@ func TestDistribute_connectionError(t *testing.T) {
 // Test that errors are transmitted across the network
 func _TestDistributeErrorFromPeer(t *testing.T) {
 	port1 := ":5551"
-	dist1 := mockPeer(t, port1)
+	dist1 := eptest.NewPeer(t, port1)
 
 	port2 := ":5552"
-	peer := mockPeer(t, port2)
+	peer := eptest.NewPeer(t, port2)
 	defer func() {
 		require.NoError(t, dist1.Close())
 		require.NoError(t, peer.Close())
 	}()
 
-	mightErrored := &dataRunner{NewDataset(), port2}
-	runner := dist1.Distribute(Pipeline(Scatter(), &nodeAddr{}, mightErrored, Gather()), port1, port2)
+	mightErrored := &dataRunner{ep.NewDataset(), port2}
+	runner := dist1.Distribute(ep.Pipeline(ep.Scatter(), &nodeAddr{}, mightErrored, ep.Gather()), port1, port2)
 
-	data1 := NewDataset(strs{"hello", "world"})
-	data2 := NewDataset(strs{"foo", "bar"})
-	data, err := TestRunner(runner, data1, data2)
+	data1 := ep.NewDataset(strs{"hello", "world"})
+	data2 := ep.NewDataset(strs{"foo", "bar"})
+	data, err := eptest.TestRunner(runner, data1, data2)
 
 	require.Error(t, err)
 	require.Equal(t, "error :5552", err.Error())

--- a/distribute_test.go
+++ b/distribute_test.go
@@ -56,7 +56,7 @@ func TestDistribute_connectionError(t *testing.T) {
 }
 
 // Test that errors are transmitted across the network
-func _TestDistributeErrorFromPeer(t *testing.T) {
+func TestDistribute_errorFromPeer(t *testing.T) {
 	port1 := ":5551"
 	dist1 := eptest.NewPeer(t, port1)
 
@@ -68,7 +68,7 @@ func _TestDistributeErrorFromPeer(t *testing.T) {
 	}()
 
 	mightErrored := &dataRunner{ep.NewDataset(), port2}
-	runner := dist1.Distribute(ep.Pipeline(ep.Scatter(), &nodeAddr{}, mightErrored, ep.Gather()), port1, port2)
+	runner := dist1.Distribute(ep.Pipeline(ep.Scatter(), &nodeAddr{}, mightErrored), port1, port2)
 
 	data1 := ep.NewDataset(strs{"hello", "world"})
 	data2 := ep.NewDataset(strs{"foo", "bar"})

--- a/ep.go
+++ b/ep.go
@@ -97,6 +97,7 @@
 package ep
 
 import (
+	"context"
 	"encoding/gob"
 	"github.com/davecgh/go-spew/spew"
 )
@@ -122,3 +123,9 @@ const (
 	thisNodeKey    ctxKey = "ep.ThisNode"
 	distributerKey ctxKey = "ep.Distributer"
 )
+
+// NodeAddress returns the current node address as saved in given context
+func NodeAddress(ctx context.Context) string {
+	thisAddress, _ := ctx.Value(thisNodeKey).(string)
+	return thisAddress
+}

--- a/ep_test.go
+++ b/ep_test.go
@@ -78,6 +78,8 @@ func (r *infinityRunner) Run(ctx context.Context, inp, out chan ep.Dataset) erro
 
 type dataRunner struct {
 	ep.Dataset
+	// ThrowOnData is a condition for throwing error. in case the last column
+	// contains exactly this string in first row - fail with error
 	ThrowOnData string
 }
 

--- a/eptest/cluster.go
+++ b/eptest/cluster.go
@@ -1,6 +1,6 @@
 package eptest
 
-// Cluster utils for writing tests with clusters
+// cluster.go contains utilities for writing tests with clusters
 
 import (
 	"fmt"

--- a/eptest/cluster.go
+++ b/eptest/cluster.go
@@ -1,0 +1,35 @@
+package eptest
+
+// Cluster utils for writing tests with clusters
+
+import (
+	"fmt"
+	"github.com/panoplyio/ep"
+	"github.com/stretchr/testify/require"
+	"net"
+	"testing"
+)
+
+// NewPeer returns distributer that listens on the given port
+func NewPeer(t *testing.T, port string) ep.Distributer {
+	ln, err := net.Listen("tcp", port)
+	require.NoError(t, err)
+	return ep.NewDistributer(port, ln)
+}
+
+// NewDialingErrorPeer returns distributer that fails to .Dial()
+func NewDialingErrorPeer(t *testing.T, port string) ep.Distributer {
+	ln, err := net.Listen("tcp", port)
+	require.NoError(t, err)
+	dialer := &errDialer{ln, fmt.Errorf("bad connection from port %s", port)}
+	return ep.NewDistributer(port, dialer)
+}
+
+type errDialer struct {
+	net.Listener
+	Err error
+}
+
+func (e *errDialer) Dial(net, addr string) (net.Conn, error) {
+	return nil, e.Err
+}

--- a/eptest/data.go
+++ b/eptest/data.go
@@ -1,14 +1,17 @@
-package ep
+package eptest
+
+// Data utils for writing data interface tests
 
 import (
 	"fmt"
+	"github.com/panoplyio/ep"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 // VerifyDataInvariant makes sure all functions (except Swap()) does not
 // modify input data, but creating a modified copy when needed
-func VerifyDataInvariant(t *testing.T, data Data) {
+func VerifyDataInvariant(t *testing.T, data ep.Data) {
 	oldLen := data.Len()
 	dataString := fmt.Sprintf("%+v", data)
 

--- a/eptest/data.go
+++ b/eptest/data.go
@@ -1,7 +1,5 @@
 package eptest
 
-// Data utils for writing data interface tests
-
 import (
 	"fmt"
 	"github.com/panoplyio/ep"
@@ -9,9 +7,9 @@ import (
 	"testing"
 )
 
-// VerifyDataInvariant makes sure all functions (except Swap()) does not
-// modify input data, but creating a modified copy when needed
-func VerifyDataInvariant(t *testing.T, data ep.Data) {
+// VerifyDataInterfaceInvariant makes sure all functions (except Swap())
+// does not modify input data, but creating a modified copy when needed
+func VerifyDataInterfaceInvariant(t *testing.T, data ep.Data) {
 	oldLen := data.Len()
 	dataString := fmt.Sprintf("%+v", data)
 

--- a/eptest/eptest.go
+++ b/eptest/eptest.go
@@ -1,21 +1,20 @@
+// Package eptest contains only tests utilities (without actual tests).
 package eptest
-
-// General utility for running a given runner with given input batches
 
 import (
 	"context"
 	"github.com/panoplyio/ep"
 )
 
-// TestRunner is helper function for tests, that runs given runner with given
+// Run is helper function for tests, that runs given runner with given
 // list of input datasets. Output is consumed up to completion, then returned
-func TestRunner(r ep.Runner, datasets ...ep.Dataset) (ep.Dataset, error) {
-	return TestRunnerWithContext(context.Background(), r, datasets...)
+func Run(r ep.Runner, datasets ...ep.Dataset) (ep.Dataset, error) {
+	return RunWithContext(context.Background(), r, datasets...)
 }
 
-// TestRunnerWithContext is helper function for tests, doing the same as TestRunner
+// RunWithContext is helper function for tests, doing the same as Run
 // with given context
-func TestRunnerWithContext(ctx context.Context, r ep.Runner, datasets ...ep.Dataset) (res ep.Dataset, err error) {
+func RunWithContext(ctx context.Context, r ep.Runner, datasets ...ep.Dataset) (res ep.Dataset, err error) {
 	inp := make(chan ep.Dataset)
 	out := make(chan ep.Dataset)
 	go func() {

--- a/eptest/eptest.go
+++ b/eptest/eptest.go
@@ -1,20 +1,23 @@
-package ep
+package eptest
+
+// General utility for running a given runner with given input batches
 
 import (
 	"context"
+	"github.com/panoplyio/ep"
 )
 
 // TestRunner is helper function for tests, that runs given runner with given
 // list of input datasets. Output is consumed up to completion, then returned
-func TestRunner(r Runner, datasets ...Dataset) (Dataset, error) {
+func TestRunner(r ep.Runner, datasets ...ep.Dataset) (ep.Dataset, error) {
 	return TestRunnerWithContext(context.Background(), r, datasets...)
 }
 
 // TestRunnerWithContext is helper function for tests, doing the same as TestRunner
 // with given context
-func TestRunnerWithContext(ctx context.Context, r Runner, datasets ...Dataset) (res Dataset, err error) {
-	inp := make(chan Dataset)
-	out := make(chan Dataset)
+func TestRunnerWithContext(ctx context.Context, r ep.Runner, datasets ...ep.Dataset) (res ep.Dataset, err error) {
+	inp := make(chan ep.Dataset)
+	out := make(chan ep.Dataset)
 	go func() {
 		err = r.Run(ctx, inp, out)
 		close(out)
@@ -27,9 +30,9 @@ func TestRunnerWithContext(ctx context.Context, r Runner, datasets ...Dataset) (
 		close(inp)
 	}()
 
-	res = NewDataset()
+	res = ep.NewDataset()
 	for data := range out {
-		res = res.Append(data).(Dataset)
+		res = res.Append(data).(ep.Dataset)
 	}
 	return res, err
 }

--- a/exchange_internal_test.go
+++ b/exchange_internal_test.go
@@ -1,0 +1,43 @@
+package ep
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"net"
+	"testing"
+)
+
+// Tests the scattering when there's just one node - the whole thing should
+// be short-circuited to act as a pass-through
+func TestExchangeInit_closeAllConnectionsUponError(t *testing.T) {
+	port := ":5551"
+	ln, err := net.Listen("tcp", port)
+	require.NoError(t, err)
+	dist := NewDistributer(port, ln)
+
+	port2 := ":5552"
+
+	ctx := context.WithValue(context.Background(), distributerKey, dist)
+	ctx = context.WithValue(ctx, allNodesKey, []string{port, port2})
+	ctx = context.WithValue(ctx, masterNodeKey, port)
+	ctx = context.WithValue(ctx, thisNodeKey, port)
+
+	exchange := Scatter().(*exchange)
+	err = exchange.Init(ctx)
+
+	require.Error(t, err)
+	require.Equal(t, "dial tcp :5552: connect: connection refused", err.Error())
+	require.Equal(t, 1, len(exchange.conns))
+	require.IsType(t, &shortCircuit{}, exchange.conns[0])
+	require.True(t, (exchange.conns[0]).(*shortCircuit).closed, "open connections leak")
+	require.NoError(t, dist.Close())
+}
+
+// UID should be unique per generated exchange function
+func TestExchange_unique(t *testing.T) {
+	s1 := Scatter().(*exchange)
+	s2 := Scatter().(*exchange)
+	s3 := Gather().(*exchange)
+	require.NotEqual(t, s1.UID, s2.UID)
+	require.NotEqual(t, s2.UID, s3.UID)
+}

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -1,8 +1,9 @@
-package ep
+package ep_test
 
 import (
-	"context"
 	"fmt"
+	"github.com/panoplyio/ep"
+	"github.com/panoplyio/ep/eptest"
 	"github.com/stretchr/testify/require"
 	"net"
 	"strings"
@@ -15,18 +16,18 @@ import (
 // Pipelining into a Gather runner would recollected the scattered outputs
 func ExampleScatter() {
 	ln1, _ := net.Listen("tcp", ":5551")
-	dist1 := NewDistributer(":5551", ln1)
+	dist1 := ep.NewDistributer(":5551", ln1)
 	defer dist1.Close()
 
 	ln2, _ := net.Listen("tcp", ":5552")
-	dist2 := NewDistributer(":5552", ln2)
+	dist2 := ep.NewDistributer(":5552", ln2)
 	defer dist2.Close()
 
-	runner := dist1.Distribute(Scatter(), ":5551", ":5552")
+	runner := dist1.Distribute(ep.Scatter(), ":5551", ":5552")
 
-	data1 := NewDataset(strs{"hello", "world"})
-	data2 := NewDataset(strs{"foo", "bar"})
-	data, err := TestRunner(runner, data1, data2)
+	data1 := ep.NewDataset(strs{"hello", "world"})
+	data2 := ep.NewDataset(strs{"foo", "bar"})
+	data, err := eptest.TestRunner(runner, data1, data2)
 	fmt.Println(data.Strings(), err) // no gather - only one batch should return
 
 	// Output:
@@ -35,33 +36,33 @@ func ExampleScatter() {
 
 func TestExchange_dialingError(t *testing.T) {
 	port1 := ":5551"
-	dist1 := mockPeer(t, port1)
+	dist1 := eptest.NewPeer(t, port1)
 
 	port2 := ":5552"
-	peer2 := mockErrorPeer(t, port2)
+	peer2 := eptest.NewDialingErrorPeer(t, port2)
 
 	port3 := ":5553"
-	peer3 := mockPeer(t, port3)
+	peer3 := eptest.NewPeer(t, port3)
 	defer func() {
 		require.NoError(t, dist1.Close())
 		require.NoError(t, peer2.Close())
 		require.NoError(t, peer3.Close())
 	}()
 
-	runner := dist1.Distribute(Scatter(), port1, port2, port3)
+	runner := dist1.Distribute(ep.Scatter(), port1, port2, port3)
 
-	data1 := NewDataset(strs{"hello", "world"})
-	data2 := NewDataset(strs{"foo", "bar"})
-	data, err := TestRunner(runner, data1, data2)
+	data1 := ep.NewDataset(strs{"hello", "world"})
+	data2 := ep.NewDataset(strs{"foo", "bar"})
+	data, err := eptest.TestRunner(runner, data1, data2)
 
 	require.Error(t, err)
 
 	possibleErrors := []string{
-		// when interacting with peers after peers failure
+		// when interacting with peers after their failure
 		"write tcp",
 		"read tcp",
 
-		"bad connection",                        // reported by 5552, when dialing to :5553
+		"bad connection from port :5552",        // reported by 5552, when dialing to :5553
 		"ep: connect timeout; no incoming conn", // reported by 5553, when waiting to :5552
 	}
 	errMsg := err.Error()
@@ -77,121 +78,40 @@ func TestExchange_dialingError(t *testing.T) {
 // be short-circuited to act as a pass-through
 func TestScatter_singleNode(t *testing.T) {
 	port := ":5551"
-	dist := mockPeer(t, port)
+	dist := eptest.NewPeer(t, port)
 	defer func() {
 		require.NoError(t, dist.Close())
 	}()
 
-	runner := dist.Distribute(Scatter(), port)
+	runner := dist.Distribute(ep.Scatter(), port)
 
-	data1 := NewDataset(strs{"hello", "world"})
-	data2 := NewDataset(strs{"foo", "bar"})
-	data, err := TestRunner(runner, data1, data2)
+	data1 := ep.NewDataset(strs{"hello", "world"})
+	data2 := ep.NewDataset(strs{"foo", "bar"})
+	data, err := eptest.TestRunner(runner, data1, data2)
 	require.NoError(t, err)
 	require.Equal(t, 1, data.Width())
 	require.Equal(t, 4, data.Len())
 }
 
-// Tests the scattering when there's just one node - the whole thing should
-// be short-circuited to act as a pass-through
-func TestExchangeInit_closeConnectionUponError(t *testing.T) {
-	port := ":5551"
-	dist := mockPeer(t, port)
-
-	port2 := ":5552"
-	peer := mockErrorPeer(t, port2)
-	defer func() {
-		require.NoError(t, dist.Close())
-		require.NoError(t, peer.Close())
-	}()
-
-	ctx := context.WithValue(context.Background(), distributerKey, dist)
-	ctx = context.WithValue(ctx, allNodesKey, []string{port, port2, ":5553"})
-	ctx = context.WithValue(ctx, masterNodeKey, port)
-	ctx = context.WithValue(ctx, thisNodeKey, port)
-
-	exchange := Scatter().(*exchange)
-	err := exchange.Init(ctx)
-
-	require.Error(t, err)
-	require.Equal(t, 2, len(exchange.conns))
-	require.IsType(t, &shortCircuit{}, exchange.conns[0])
-	require.True(t, (exchange.conns[0]).(*shortCircuit).closed, "open connections leak")
-}
-
 func TestScatter_and_Gather(t *testing.T) {
 	port1 := ":5551"
-	dist := mockPeer(t, port1)
+	dist := eptest.NewPeer(t, port1)
 
 	port2 := ":5552"
-	peer := mockPeer(t, port2)
+	peer := eptest.NewPeer(t, port2)
 	defer func() {
 		require.NoError(t, dist.Close())
 		require.NoError(t, peer.Close())
 	}()
 
-	runner := Pipeline(Scatter(), &nodeAddr{}, Gather())
+	runner := ep.Pipeline(ep.Scatter(), &nodeAddr{}, ep.Gather())
 	runner = dist.Distribute(runner, port1, port2)
 
-	data1 := NewDataset(strs{"hello", "world"})
-	data2 := NewDataset(strs{"foo", "bar"})
-	data, err := TestRunner(runner, data1, data2)
+	data1 := ep.NewDataset(strs{"hello", "world"})
+	data2 := ep.NewDataset(strs{"foo", "bar"})
+	data, err := eptest.TestRunner(runner, data1, data2)
 
 	require.NoError(t, err)
+	require.NotNil(t, data)
 	require.Equal(t, "[[hello world foo bar] [:5552 :5552 :5551 :5551]]", fmt.Sprintf("%v", data))
-}
-
-// UID should be unique per generated exchange function
-func TestExchange_unique(t *testing.T) {
-	s1 := Scatter().(*exchange)
-	s2 := Scatter().(*exchange)
-	s3 := Gather().(*exchange)
-	require.NotEqual(t, s1.UID, s2.UID)
-	require.NotEqual(t, s2.UID, s3.UID)
-}
-
-var _ = registerGob(&nodeAddr{})
-
-type nodeAddr struct{}
-
-func (*nodeAddr) Returns() []Type { return []Type{Wildcard, str} }
-func (*nodeAddr) Run(ctx context.Context, inp, out chan Dataset) error {
-	addr := ctx.Value(thisNodeKey).(string)
-	for data := range inp {
-		res := make(strs, data.Len())
-		for i := range res {
-			res[i] = addr
-		}
-
-		outset := []Data{}
-		for i := 0; i < data.Width(); i++ {
-			outset = append(outset, data.At(i))
-		}
-
-		outset = append(outset, res)
-		out <- NewDataset(outset...)
-	}
-	return nil
-}
-
-func mockPeer(t *testing.T, port string) Distributer {
-	ln, err := net.Listen("tcp", port)
-	require.NoError(t, err)
-	return NewDistributer(port, ln)
-}
-
-func mockErrorPeer(t *testing.T, port string) Distributer {
-	ln, err := net.Listen("tcp", port)
-	require.NoError(t, err)
-	dialer := &errDialer{ln, fmt.Errorf("bad connection")}
-	return NewDistributer(port, dialer)
-}
-
-type errDialer struct {
-	net.Listener
-	Err error
-}
-
-func (e *errDialer) Dial(net, addr string) (net.Conn, error) {
-	return nil, e.Err
 }

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -27,7 +27,7 @@ func ExampleScatter() {
 
 	data1 := ep.NewDataset(strs{"hello", "world"})
 	data2 := ep.NewDataset(strs{"foo", "bar"})
-	data, err := eptest.TestRunner(runner, data1, data2)
+	data, err := eptest.Run(runner, data1, data2)
 	fmt.Println(data.Strings(), err) // no gather - only one batch should return
 
 	// Output:
@@ -53,7 +53,7 @@ func TestExchange_dialingError(t *testing.T) {
 
 	data1 := ep.NewDataset(strs{"hello", "world"})
 	data2 := ep.NewDataset(strs{"foo", "bar"})
-	data, err := eptest.TestRunner(runner, data1, data2)
+	data, err := eptest.Run(runner, data1, data2)
 
 	require.Error(t, err)
 
@@ -87,7 +87,7 @@ func TestScatter_singleNode(t *testing.T) {
 
 	data1 := ep.NewDataset(strs{"hello", "world"})
 	data2 := ep.NewDataset(strs{"foo", "bar"})
-	data, err := eptest.TestRunner(runner, data1, data2)
+	data, err := eptest.Run(runner, data1, data2)
 	require.NoError(t, err)
 	require.Equal(t, 1, data.Width())
 	require.Equal(t, 4, data.Len())
@@ -109,7 +109,7 @@ func TestScatter_and_Gather(t *testing.T) {
 
 	data1 := ep.NewDataset(strs{"hello", "world"})
 	data2 := ep.NewDataset(strs{"foo", "bar"})
-	data, err := eptest.TestRunner(runner, data1, data2)
+	data, err := eptest.Run(runner, data1, data2)
 
 	require.NoError(t, err)
 	require.NotNil(t, data)

--- a/nulls_test.go
+++ b/nulls_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestNullsInvariant(t *testing.T) {
-	eptest.VerifyDataInvariant(t, ep.Null.Data(10))
+	eptest.VerifyDataInterfaceInvariant(t, ep.Null.Data(10))
 }

--- a/nulls_test.go
+++ b/nulls_test.go
@@ -1,9 +1,11 @@
-package ep
+package ep_test
 
 import (
+	"github.com/panoplyio/ep"
+	"github.com/panoplyio/ep/eptest"
 	"testing"
 )
 
 func TestNullsInvariant(t *testing.T) {
-	VerifyDataInvariant(t, Null.Data(10))
+	eptest.VerifyDataInvariant(t, ep.Null.Data(10))
 }

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -1,0 +1,105 @@
+package ep
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestPipeline_creation_single_runner(t *testing.T) {
+	runner := Pipeline(Gather())
+	_, isPipe := runner.(pipeline)
+	require.False(t, isPipe)
+
+	passThrough := Pipeline(PassThrough())
+	_, isPipe = passThrough.(pipeline)
+	require.False(t, isPipe)
+
+	projectWithPipeline := Pipeline(Project(Pipeline(Scatter(), Scatter()), Gather()))
+	_, isPipe = projectWithPipeline.(pipeline)
+	require.False(t, isPipe)
+
+	nestedPipeline := Pipeline(Pipeline(Scatter(), Scatter()))
+	p, isPipe := nestedPipeline.(pipeline)
+	require.True(t, isPipe)
+	require.Equal(t, 2, len(p))
+	_, isPipe = p[0].(pipeline)
+	require.False(t, isPipe)
+}
+
+func TestPipeline_creation_flat(t *testing.T) {
+	runner := Pipeline(Gather(), Scatter())
+	runner = Pipeline(runner, Pipeline(Scatter(), Pipeline(Scatter(), Scatter())))
+
+	p, isPipe := runner.(pipeline)
+	require.True(t, isPipe)
+	require.Equal(t, 5, len(p))
+}
+
+func TestPipeline_creation_flat_skip_passthrogh(t *testing.T) {
+	runner := Pipeline(Gather(), PassThrough())
+	runner = Pipeline(runner, Pipeline(Scatter(), Pipeline(PassThrough(), Scatter())))
+
+	p, isPipe := runner.(pipeline)
+	require.True(t, isPipe)
+	// 5 runners without 2 skipped passThrough
+	require.Equal(t, 3, len(p))
+}
+
+func TestPipeline_creation_dont_flat_project(t *testing.T) {
+	runner := Project(Gather(), Pipeline(Scatter(), Scatter()), Pipeline(Scatter(), Scatter()))
+	runner = Pipeline(runner, Gather())
+
+	p, isPipe := runner.(pipeline)
+	require.True(t, isPipe)
+	require.Equal(t, 2, len(p))
+}
+
+func TestPipeline_creation_single_runner_after_flat(t *testing.T) {
+	runner := Pipeline(PassThrough(), Gather(), PassThrough())
+	_, isPipe := runner.(pipeline)
+	require.False(t, isPipe)
+
+	nestedPipeline := Pipeline(PassThrough(), Pipeline(Gather(), PassThrough()), PassThrough())
+	_, isPipe = nestedPipeline.(pipeline)
+	require.False(t, isPipe)
+
+	onlyPassThrough := Pipeline(PassThrough(), PassThrough())
+	_, isPipe = onlyPassThrough.(pipeline)
+	require.False(t, isPipe)
+	_, isPassThrough := onlyPassThrough.(*passthrough)
+	require.True(t, isPassThrough)
+
+	nestedPipelineWithOnlyPassThrough := Pipeline(
+		PassThrough(),
+		Pipeline(PassThrough(), PassThrough()),
+		PassThrough(),
+		Pipeline(PassThrough(), Pipeline(PassThrough(), PassThrough())),
+	)
+	_, isPipe = nestedPipelineWithOnlyPassThrough.(pipeline)
+	require.False(t, isPipe)
+	_, isPassThrough = onlyPassThrough.(*passthrough)
+	require.True(t, isPassThrough)
+}
+
+// Measures the number of datasets (ops) per second going through a pipeline
+// composed of 3 pass-throughs. At the time of writing, it was evident that
+// performance is not impacted by the size of the datasets (sensible, given
+// the implementation details).
+func BenchmarkPipeline(b *testing.B) {
+	data := NewDataset(Null.Data(4))
+	inp := make(chan Dataset)
+	out := make(chan Dataset)
+	defer close(inp)
+	defer close(out)
+
+	r := pipeline{PassThrough(), PassThrough(), PassThrough()}
+	go r.Run(context.Background(), inp, out)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// run a single dataset through the pipeline
+		inp <- data
+		<-out
+	}
+}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -1,16 +1,18 @@
-package ep
+package ep_test
 
 import (
 	"context"
 	"fmt"
+	"github.com/panoplyio/ep"
+	"github.com/panoplyio/ep/eptest"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 func ExamplePipeline() {
-	runner := Pipeline(&upper{}, &question{})
-	data := NewDataset(strs([]string{"hello", "world"}))
-	data, err := TestRunner(runner, data)
+	runner := ep.Pipeline(&upper{}, &question{})
+	data := ep.NewDataset(strs([]string{"hello", "world"}))
+	data, err := eptest.TestRunner(runner, data)
 	fmt.Println(data.Strings(), err)
 
 	// Output:
@@ -19,9 +21,9 @@ func ExamplePipeline() {
 }
 
 func ExamplePipeline_reverse() {
-	runner := Pipeline(&question{}, &upper{})
-	data := NewDataset(strs([]string{"hello", "world"}))
-	data, err := TestRunner(runner, data)
+	runner := ep.Pipeline(&question{}, &upper{})
+	data := ep.NewDataset(strs([]string{"hello", "world"}))
+	data, err := eptest.TestRunner(runner, data)
 	fmt.Println(data.Strings(), err)
 
 	// Output:
@@ -34,9 +36,9 @@ func TestPipeline_errInFirstRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
-	runner := Pipeline(&errRunner{err}, infinityRunner1, infinityRunner2)
-	data := NewDataset(Null.Data(1))
-	data, err = TestRunner(runner, data)
+	runner := ep.Pipeline(&errRunner{err}, infinityRunner1, infinityRunner2)
+	data := ep.NewDataset(ep.Null.Data(1))
+	data, err = eptest.TestRunner(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -51,9 +53,9 @@ func TestPipeline_errInSecondRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
-	runner := Pipeline(infinityRunner1, &errRunner{err}, infinityRunner2)
-	data := NewDataset(Null.Data(1))
-	data, err = TestRunner(runner, data)
+	runner := ep.Pipeline(infinityRunner1, &errRunner{err}, infinityRunner2)
+	data := ep.NewDataset(ep.Null.Data(1))
+	data, err = eptest.TestRunner(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -68,9 +70,9 @@ func TestPipeline_errInThirdRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
-	runner := Pipeline(infinityRunner1, infinityRunner2, &errRunner{err})
-	data := NewDataset(Null.Data(1))
-	data, err = TestRunner(runner, data)
+	runner := ep.Pipeline(infinityRunner1, infinityRunner2, &errRunner{err})
+	data := ep.NewDataset(ep.Null.Data(1))
+	data, err = eptest.TestRunner(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -86,12 +88,12 @@ func TestPipeline_errInNestedPipeline(t *testing.T) {
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
 	infinityRunner3 := &infinityRunner{}
-	runner := Pipeline(
-		Pipeline(infinityRunner1, &errRunner{err}),
-		Pipeline(infinityRunner2, infinityRunner3),
+	runner := ep.Pipeline(
+		ep.Pipeline(infinityRunner1, &errRunner{err}),
+		ep.Pipeline(infinityRunner2, infinityRunner3),
 	)
-	data := NewDataset(Null.Data(1))
-	data, err = TestRunner(runner, data)
+	data := ep.NewDataset(ep.Null.Data(1))
+	data, err = eptest.TestRunner(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -114,17 +116,17 @@ func TestPipeline_errNestedPipelineWithProject(t *testing.T) {
 	infinityRunner6 := &infinityRunner{}
 	infinityRunner7 := &infinityRunner{}
 	runner :=
-		Pipeline(
-			Project(
-				Pipeline(infinityRunner1, infinityRunner4),
-				Pipeline(infinityRunner2, infinityRunner5),
+		ep.Pipeline(
+			ep.Project(
+				ep.Pipeline(infinityRunner1, infinityRunner4),
+				ep.Pipeline(infinityRunner2, infinityRunner5),
 			),
-			Project(
-				Pipeline(infinityRunner3, infinityRunner6),
-				Pipeline(infinityRunner7, &errRunner{err}),
+			ep.Project(
+				ep.Pipeline(infinityRunner3, infinityRunner6),
+				ep.Pipeline(infinityRunner7, &errRunner{err}),
 			))
-	data := NewDataset(Null.Data(1))
-	data, err = TestRunner(runner, data)
+	data := ep.NewDataset(ep.Null.Data(1))
+	data, err = eptest.TestRunner(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -134,149 +136,47 @@ func TestPipeline_errNestedPipelineWithProject(t *testing.T) {
 	require.Equal(t, false, infinityRunner3.IsRunning(), "Infinity go-routine leak")
 }
 
-func TestPipeline_creation_empty_panic(t *testing.T) {
-	require.Panics(t, func() { Pipeline() })
-}
-
-func TestPipeline_creation_single_runner(t *testing.T) {
-	runner := Pipeline(&upper{})
-	_, isPipe := runner.(pipeline)
-	require.False(t, isPipe)
-
-	passThrough := Pipeline(PassThrough())
-	_, isPipe = passThrough.(pipeline)
-	require.False(t, isPipe)
-
-	projectWithPipeline := Pipeline(Project(Pipeline(&question{}, &question{}), &upper{}))
-	_, isPipe = projectWithPipeline.(pipeline)
-	require.False(t, isPipe)
-
-	nestedPipeline := Pipeline(Pipeline(&question{}, &question{}))
-	p, isPipe := nestedPipeline.(pipeline)
-	require.True(t, isPipe)
-	require.Equal(t, 2, len(p))
-	_, isPipe = p[0].(pipeline)
-	require.False(t, isPipe)
-}
-
-func TestPipeline_creation_flat(t *testing.T) {
-	runner := Pipeline(&upper{}, &question{})
-	runner = Pipeline(runner, Pipeline(&question{}, Pipeline(&question{}, &question{})))
-
-	p, isPipe := runner.(pipeline)
-	require.True(t, isPipe)
-	require.Equal(t, 5, len(p))
-}
-
-func TestPipeline_creation_flat_skip_passthrogh(t *testing.T) {
-	runner := Pipeline(&upper{}, PassThrough())
-	runner = Pipeline(runner, Pipeline(&question{}, Pipeline(PassThrough(), &question{})))
-
-	p, isPipe := runner.(pipeline)
-	require.True(t, isPipe)
-	// 5 runners without 2 skipped passThrough
-	require.Equal(t, 3, len(p))
-}
-
-func TestPipeline_creation_dont_flat_project(t *testing.T) {
-	runner := Project(&upper{}, Pipeline(&question{}, &question{}), Pipeline(&question{}, &question{}))
-	runner = Pipeline(runner, &upper{})
-
-	p, isPipe := runner.(pipeline)
-	require.True(t, isPipe)
-	require.Equal(t, 2, len(p))
-}
-
-func TestPipeline_creation_single_runner_after_flat(t *testing.T) {
-	runner := Pipeline(PassThrough(), &upper{}, PassThrough())
-	_, isPipe := runner.(pipeline)
-	require.False(t, isPipe)
-
-	nestedPipeline := Pipeline(PassThrough(), Pipeline(&upper{}, PassThrough()), PassThrough())
-	_, isPipe = nestedPipeline.(pipeline)
-	require.False(t, isPipe)
-
-	onlyPassThrough := Pipeline(PassThrough(), PassThrough())
-	_, isPipe = onlyPassThrough.(pipeline)
-	require.False(t, isPipe)
-	_, isPassThrough := onlyPassThrough.(*passthrough)
-	require.True(t, isPassThrough)
-
-	nestedPipelineWithOnlyPassThrough := Pipeline(
-		PassThrough(),
-		Pipeline(PassThrough(), PassThrough()),
-		PassThrough(),
-		Pipeline(PassThrough(), Pipeline(PassThrough(), PassThrough())),
-	)
-	_, isPipe = nestedPipelineWithOnlyPassThrough.(pipeline)
-	require.False(t, isPipe)
-	_, isPassThrough = onlyPassThrough.(*passthrough)
-	require.True(t, isPassThrough)
-}
-
 func TestPipeline_Returns_wildcard(t *testing.T) {
-	runner := Project(&upper{}, &question{})
-	runner = Pipeline(runner, PassThrough())
+	runner := ep.Project(&upper{}, &question{})
+	runner = ep.Pipeline(runner, ep.PassThrough())
 	types := runner.Returns()
 	require.Equal(t, 2, len(types))
 	require.Equal(t, str.Name(), types[0].Name())
 	require.Equal(t, str.Name(), types[1].Name())
 
-	runner = Project(&upper{}, &question{})
-	runner = Pipeline(runner, Pick(1))
+	runner = ep.Project(&upper{}, &question{})
+	runner = ep.Pipeline(runner, ep.Pick(1))
 	types = runner.Returns()
 	require.Equal(t, 1, len(types))
 }
 
 func TestPipeline_Returns_wildcardIdx(t *testing.T) {
-	runner := Project(&upper{}, &question{}, &question{})
-	runner = Pipeline(runner, Pick(1, 2))
+	runner := ep.Project(&upper{}, &question{}, &question{})
+	runner = ep.Pipeline(runner, ep.Pick(1, 2))
 	types := runner.Returns()
 	require.Equal(t, 2, len(types))
 	require.Equal(t, str.Name(), types[0].Name())
 	require.Equal(t, str.Name(), types[1].Name())
-	require.Equal(t, "question", GetAlias(types[0]))
-	require.Equal(t, "question", GetAlias(types[1]))
+	require.Equal(t, "question", ep.GetAlias(types[0]))
+	require.Equal(t, "question", ep.GetAlias(types[1]))
 }
 
 func TestPipeline_Returns_wildcardMinusTail(t *testing.T) {
-	runner := Project(&upper{}, &question{}, &upper{})
-	runner = Pipeline(runner, &tailCutter{2})
+	runner := ep.Project(&upper{}, &question{}, &upper{})
+	runner = ep.Pipeline(runner, &tailCutter{2})
 
 	types := runner.Returns()
 	require.Equal(t, 1, len(types))
 	require.Equal(t, str.Name(), types[0].Name())
-	require.Equal(t, "upper", GetAlias(types[0]))
-}
-
-// Measures the number of datasets (ops) per second going through a pipeline
-// composed of 3 pass-throughs. At the time of writing, it was evident that
-// performance is not impacted by the size of the datasets (sensible, given
-// the implementation details).
-func BenchmarkPipeline(b *testing.B) {
-	data := NewDataset(strs([]string{"hello", "world", "foo", "bar"}))
-	inp := make(chan Dataset)
-	out := make(chan Dataset)
-	defer close(inp)
-	defer close(out)
-
-	r := pipeline{PassThrough(), PassThrough(), PassThrough()}
-	go r.Run(context.Background(), inp, out)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		// run a single dataset through the pipeline
-		inp <- data
-		<-out
-	}
+	require.Equal(t, "upper", ep.GetAlias(types[0]))
 }
 
 type tailCutter struct {
 	CutFromTail int
 }
 
-func (r *tailCutter) Returns() []Type { return []Type{WildcardMinusTail(r.CutFromTail)} }
-func (*tailCutter) Run(_ context.Context, inp, out chan Dataset) error {
+func (r *tailCutter) Returns() []ep.Type { return []ep.Type{ep.WildcardMinusTail(r.CutFromTail)} }
+func (*tailCutter) Run(_ context.Context, inp, out chan ep.Dataset) error {
 	for data := range inp {
 		out <- data
 	}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -36,7 +36,7 @@ func TestPipeline_errInFirstRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
-	runner := ep.Pipeline(&errRunner{err}, infinityRunner1, infinityRunner2)
+	runner := ep.Pipeline(NewErrRunner(err), infinityRunner1, infinityRunner2)
 	data := ep.NewDataset(ep.Null.Data(1))
 	data, err = eptest.TestRunner(runner, data)
 
@@ -53,7 +53,7 @@ func TestPipeline_errInSecondRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
-	runner := ep.Pipeline(infinityRunner1, &errRunner{err}, infinityRunner2)
+	runner := ep.Pipeline(infinityRunner1, NewErrRunner(err), infinityRunner2)
 	data := ep.NewDataset(ep.Null.Data(1))
 	data, err = eptest.TestRunner(runner, data)
 
@@ -70,7 +70,7 @@ func TestPipeline_errInThirdRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
-	runner := ep.Pipeline(infinityRunner1, infinityRunner2, &errRunner{err})
+	runner := ep.Pipeline(infinityRunner1, infinityRunner2, NewErrRunner(err))
 	data := ep.NewDataset(ep.Null.Data(1))
 	data, err = eptest.TestRunner(runner, data)
 
@@ -89,7 +89,7 @@ func TestPipeline_errInNestedPipeline(t *testing.T) {
 	infinityRunner2 := &infinityRunner{}
 	infinityRunner3 := &infinityRunner{}
 	runner := ep.Pipeline(
-		ep.Pipeline(infinityRunner1, &errRunner{err}),
+		ep.Pipeline(infinityRunner1, NewErrRunner(err)),
 		ep.Pipeline(infinityRunner2, infinityRunner3),
 	)
 	data := ep.NewDataset(ep.Null.Data(1))
@@ -123,7 +123,7 @@ func TestPipeline_errNestedPipelineWithProject(t *testing.T) {
 			),
 			ep.Project(
 				ep.Pipeline(infinityRunner3, infinityRunner6),
-				ep.Pipeline(infinityRunner7, &errRunner{err}),
+				ep.Pipeline(infinityRunner7, NewErrRunner(err)),
 			))
 	data := ep.NewDataset(ep.Null.Data(1))
 	data, err = eptest.TestRunner(runner, data)

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -12,7 +12,7 @@ import (
 func ExamplePipeline() {
 	runner := ep.Pipeline(&upper{}, &question{})
 	data := ep.NewDataset(strs([]string{"hello", "world"}))
-	data, err := eptest.TestRunner(runner, data)
+	data, err := eptest.Run(runner, data)
 	fmt.Println(data.Strings(), err)
 
 	// Output:
@@ -23,7 +23,7 @@ func ExamplePipeline() {
 func ExamplePipeline_reverse() {
 	runner := ep.Pipeline(&question{}, &upper{})
 	data := ep.NewDataset(strs([]string{"hello", "world"}))
-	data, err := eptest.TestRunner(runner, data)
+	data, err := eptest.Run(runner, data)
 	fmt.Println(data.Strings(), err)
 
 	// Output:
@@ -38,7 +38,7 @@ func TestPipeline_errInFirstRunner(t *testing.T) {
 	infinityRunner2 := &infinityRunner{}
 	runner := ep.Pipeline(NewErrRunner(err), infinityRunner1, infinityRunner2)
 	data := ep.NewDataset(ep.Null.Data(1))
-	data, err = eptest.TestRunner(runner, data)
+	data, err = eptest.Run(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -55,7 +55,7 @@ func TestPipeline_errInSecondRunner(t *testing.T) {
 	infinityRunner2 := &infinityRunner{}
 	runner := ep.Pipeline(infinityRunner1, NewErrRunner(err), infinityRunner2)
 	data := ep.NewDataset(ep.Null.Data(1))
-	data, err = eptest.TestRunner(runner, data)
+	data, err = eptest.Run(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -72,7 +72,7 @@ func TestPipeline_errInThirdRunner(t *testing.T) {
 	infinityRunner2 := &infinityRunner{}
 	runner := ep.Pipeline(infinityRunner1, infinityRunner2, NewErrRunner(err))
 	data := ep.NewDataset(ep.Null.Data(1))
-	data, err = eptest.TestRunner(runner, data)
+	data, err = eptest.Run(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -93,7 +93,7 @@ func TestPipeline_errInNestedPipeline(t *testing.T) {
 		ep.Pipeline(infinityRunner2, infinityRunner3),
 	)
 	data := ep.NewDataset(ep.Null.Data(1))
-	data, err = eptest.TestRunner(runner, data)
+	data, err = eptest.Run(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -126,7 +126,7 @@ func TestPipeline_errNestedPipelineWithProject(t *testing.T) {
 				ep.Pipeline(infinityRunner7, NewErrRunner(err)),
 			))
 	data := ep.NewDataset(ep.Null.Data(1))
-	data, err = eptest.TestRunner(runner, data)
+	data, err = eptest.Run(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)

--- a/project.go
+++ b/project.go
@@ -47,7 +47,7 @@ func (rs project) Run(origCtx context.Context, inp, out chan Dataset) (err error
 		wg.Wait()
 		// choose first error out from all errors, that isn't project internal error
 		for _, errI := range errs {
-			if errI != nil && errI != errProjectState {
+			if errI != nil && errI.Error() != errProjectState.Error() {
 				err = errI
 				break
 			}

--- a/project_test.go
+++ b/project_test.go
@@ -32,7 +32,7 @@ func ExampleProject_reversed() {
 func TestProject_errorInFirstRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinity := &infinityRunner{}
-	runner := ep.Project(&errRunner{err}, infinity)
+	runner := ep.Project(NewErrRunner(err), infinity)
 	data := ep.NewDataset(ep.Null.Data(1))
 	data, err = eptest.TestRunner(runner, data)
 
@@ -46,7 +46,7 @@ func TestProject_errorInSecondRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
-	runner := ep.Project(infinityRunner1, &errRunner{err}, infinityRunner2)
+	runner := ep.Project(infinityRunner1, NewErrRunner(err), infinityRunner2)
 	data := ep.NewDataset(ep.Null.Data(1))
 	data, err = eptest.TestRunner(runner, data)
 
@@ -61,7 +61,7 @@ func TestProject_errorInThirdRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
-	runner := ep.Project(infinityRunner1, infinityRunner2, &errRunner{err})
+	runner := ep.Project(infinityRunner1, infinityRunner2, NewErrRunner(err))
 	data := ep.NewDataset(ep.Null.Data(1))
 	data, err = eptest.TestRunner(runner, data)
 
@@ -79,7 +79,7 @@ func TestProject_errorInPipeline(t *testing.T) {
 	infinityRunner3 := &infinityRunner{}
 	runner := ep.Project(
 		ep.Pipeline(infinityRunner1, infinityRunner2),
-		ep.Pipeline(infinityRunner3, &errRunner{err}),
+		ep.Pipeline(infinityRunner3, NewErrRunner(err)),
 	)
 	data := ep.NewDataset(ep.Null.Data(1))
 	data, err = eptest.TestRunner(runner, data)
@@ -92,7 +92,7 @@ func TestProject_errorInPipeline(t *testing.T) {
 	require.Equal(t, false, infinityRunner3.IsRunning(), "Infinity 3 go-routine leak")
 }
 
-func _TestProject_errorWithExchange(t *testing.T) { // TODO avia
+func TestProject_errorWithExchange(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner := &infinityRunner{}
 
@@ -106,7 +106,7 @@ func _TestProject_errorWithExchange(t *testing.T) { // TODO avia
 
 	runner := ep.Pipeline(
 		infinityRunner,
-		ep.Project(ep.Scatter(), &errRunner{err}),
+		ep.Project(ep.Scatter(), NewErrRunner(err)),
 	)
 	runner = dist.Distribute(runner, port, port2)
 
@@ -125,7 +125,7 @@ func TestProject_nested_errorInFirstRunner(t *testing.T) {
 	infinityRunner2 := &infinityRunner{}
 	infinityRunner3 := &infinityRunner{}
 	runner := ep.Project(
-		ep.Project(infinityRunner3, &errRunner{err}),
+		ep.Project(infinityRunner3, NewErrRunner(err)),
 		ep.Project(infinityRunner1, infinityRunner2),
 	)
 	data := ep.NewDataset(ep.Null.Data(1))
@@ -146,7 +146,7 @@ func TestProject_nested_errorInSecondRunner(t *testing.T) {
 	infinityRunner3 := &infinityRunner{}
 	runner := ep.Project(
 		ep.Project(infinityRunner1, infinityRunner2),
-		ep.Project(infinityRunner3, &errRunner{err}),
+		ep.Project(infinityRunner3, NewErrRunner(err)),
 	)
 	data := ep.NewDataset(ep.Null.Data(1))
 	data, err = eptest.TestRunner(runner, data)

--- a/project_test.go
+++ b/project_test.go
@@ -12,7 +12,7 @@ import (
 func ExampleProject() {
 	runner := ep.Project(&upper{}, &question{})
 	data := ep.NewDataset(strs([]string{"hello", "world"}))
-	data, err := eptest.TestRunner(runner, data)
+	data, err := eptest.Run(runner, data)
 	fmt.Println(data.Strings(), err)
 
 	// Output:
@@ -22,7 +22,7 @@ func ExampleProject() {
 func ExampleProject_reversed() {
 	runner := ep.Project(&question{}, &upper{})
 	data := ep.NewDataset(strs([]string{"hello", "world"}))
-	data, err := eptest.TestRunner(runner, data)
+	data, err := eptest.Run(runner, data)
 	fmt.Println(data.Strings(), err)
 
 	// Output:
@@ -34,7 +34,7 @@ func TestProject_errorInFirstRunner(t *testing.T) {
 	infinity := &infinityRunner{}
 	runner := ep.Project(NewErrRunner(err), infinity)
 	data := ep.NewDataset(ep.Null.Data(1))
-	data, err = eptest.TestRunner(runner, data)
+	data, err = eptest.Run(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -48,7 +48,7 @@ func TestProject_errorInSecondRunner(t *testing.T) {
 	infinityRunner2 := &infinityRunner{}
 	runner := ep.Project(infinityRunner1, NewErrRunner(err), infinityRunner2)
 	data := ep.NewDataset(ep.Null.Data(1))
-	data, err = eptest.TestRunner(runner, data)
+	data, err = eptest.Run(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -63,7 +63,7 @@ func TestProject_errorInThirdRunner(t *testing.T) {
 	infinityRunner2 := &infinityRunner{}
 	runner := ep.Project(infinityRunner1, infinityRunner2, NewErrRunner(err))
 	data := ep.NewDataset(ep.Null.Data(1))
-	data, err = eptest.TestRunner(runner, data)
+	data, err = eptest.Run(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -82,7 +82,7 @@ func TestProject_errorInPipeline(t *testing.T) {
 		ep.Pipeline(infinityRunner3, NewErrRunner(err)),
 	)
 	data := ep.NewDataset(ep.Null.Data(1))
-	data, err = eptest.TestRunner(runner, data)
+	data, err = eptest.Run(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -111,7 +111,7 @@ func TestProject_errorWithExchange(t *testing.T) {
 	runner = dist.Distribute(runner, port, port2)
 
 	data := ep.NewDataset(ep.Null.Data(1))
-	data, err = eptest.TestRunner(runner, data)
+	data, err = eptest.Run(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -129,7 +129,7 @@ func TestProject_nested_errorInFirstRunner(t *testing.T) {
 		ep.Project(infinityRunner1, infinityRunner2),
 	)
 	data := ep.NewDataset(ep.Null.Data(1))
-	data, err = eptest.TestRunner(runner, data)
+	data, err = eptest.Run(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -149,7 +149,7 @@ func TestProject_nested_errorInSecondRunner(t *testing.T) {
 		ep.Project(infinityRunner3, NewErrRunner(err)),
 	)
 	data := ep.NewDataset(ep.Null.Data(1))
-	data, err = eptest.TestRunner(runner, data)
+	data, err = eptest.Run(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -163,7 +163,7 @@ func TestProject_nested_errorInSecondRunner(t *testing.T) {
 func TestProject_errorMismatchRows(t *testing.T) {
 	runner := ep.Project(&upper{}, &count{})
 	data := ep.NewDataset(strs([]string{"hello", "world"}))
-	_, err := eptest.TestRunner(runner, data)
+	_, err := eptest.Run(runner, data)
 	require.Error(t, err)
 	require.Equal(t, "mismatched number of rows", err.Error())
 }

--- a/project_test.go
+++ b/project_test.go
@@ -111,7 +111,7 @@ func TestProject_errorWithExchange(t *testing.T) {
 	runner = dist.Distribute(runner, port, port2)
 
 	data := ep.NewDataset(ep.Null.Data(1))
-	data, err = eptest.Run(runner, data)
+	data, err = eptest.Run(runner, data, data, data, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)

--- a/project_test.go
+++ b/project_test.go
@@ -92,7 +92,7 @@ func TestProject_errorInPipeline(t *testing.T) {
 	require.Equal(t, false, infinityRunner3.IsRunning(), "Infinity 3 go-routine leak")
 }
 
-func TestProject_errorWithExchange(t *testing.T) {
+func _TestProject_errorWithExchange(t *testing.T) { // TODO avia
 	err := fmt.Errorf("something bad happened")
 	infinityRunner := &infinityRunner{}
 
@@ -101,7 +101,7 @@ func TestProject_errorWithExchange(t *testing.T) {
 	defer dist.Close()
 
 	port2 := ":5552"
-	peer2 := eptest.NewPeer(t, port)
+	peer2 := eptest.NewPeer(t, port2)
 	defer peer2.Close()
 
 	runner := ep.Pipeline(

--- a/project_test.go
+++ b/project_test.go
@@ -117,7 +117,7 @@ func TestProject_errorWithExchange(t *testing.T) {
 	data, err := eptest.Run(runner, data, data, data, data)
 
 	require.Error(t, err)
-	require.Equal(t, "error " + port2, err.Error())
+	require.Equal(t, "error "+port2, err.Error())
 	require.Equal(t, false, infinityRunner.IsRunning(), "Infinity go-routine leak")
 }
 

--- a/project_test.go
+++ b/project_test.go
@@ -1,16 +1,18 @@
-package ep
+package ep_test
 
 import (
 	"context"
 	"fmt"
+	"github.com/panoplyio/ep"
+	"github.com/panoplyio/ep/eptest"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 func ExampleProject() {
-	runner := Project(&upper{}, &question{})
-	data := NewDataset(strs([]string{"hello", "world"}))
-	data, err := TestRunner(runner, data)
+	runner := ep.Project(&upper{}, &question{})
+	data := ep.NewDataset(strs([]string{"hello", "world"}))
+	data, err := eptest.TestRunner(runner, data)
 	fmt.Println(data.Strings(), err)
 
 	// Output:
@@ -18,9 +20,9 @@ func ExampleProject() {
 }
 
 func ExampleProject_reversed() {
-	runner := Project(&question{}, &upper{})
-	data := NewDataset(strs([]string{"hello", "world"}))
-	data, err := TestRunner(runner, data)
+	runner := ep.Project(&question{}, &upper{})
+	data := ep.NewDataset(strs([]string{"hello", "world"}))
+	data, err := eptest.TestRunner(runner, data)
 	fmt.Println(data.Strings(), err)
 
 	// Output:
@@ -30,9 +32,9 @@ func ExampleProject_reversed() {
 func TestProject_errorInFirstRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinity := &infinityRunner{}
-	runner := Project(&errRunner{err}, infinity)
-	data := NewDataset(Null.Data(1))
-	data, err = TestRunner(runner, data)
+	runner := ep.Project(&errRunner{err}, infinity)
+	data := ep.NewDataset(ep.Null.Data(1))
+	data, err = eptest.TestRunner(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -44,9 +46,9 @@ func TestProject_errorInSecondRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
-	runner := Project(infinityRunner1, &errRunner{err}, infinityRunner2)
-	data := NewDataset(Null.Data(1))
-	data, err = TestRunner(runner, data)
+	runner := ep.Project(infinityRunner1, &errRunner{err}, infinityRunner2)
+	data := ep.NewDataset(ep.Null.Data(1))
+	data, err = eptest.TestRunner(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -59,9 +61,9 @@ func TestProject_errorInThirdRunner(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
-	runner := Project(infinityRunner1, infinityRunner2, &errRunner{err})
-	data := NewDataset(Null.Data(1))
-	data, err = TestRunner(runner, data)
+	runner := ep.Project(infinityRunner1, infinityRunner2, &errRunner{err})
+	data := ep.NewDataset(ep.Null.Data(1))
+	data, err = eptest.TestRunner(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -75,12 +77,12 @@ func TestProject_errorInPipeline(t *testing.T) {
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
 	infinityRunner3 := &infinityRunner{}
-	runner := Project(
-		Pipeline(infinityRunner1, infinityRunner2),
-		Pipeline(infinityRunner3, &errRunner{err}),
+	runner := ep.Project(
+		ep.Pipeline(infinityRunner1, infinityRunner2),
+		ep.Pipeline(infinityRunner3, &errRunner{err}),
 	)
-	data := NewDataset(Null.Data(1))
-	data, err = TestRunner(runner, data)
+	data := ep.NewDataset(ep.Null.Data(1))
+	data, err = eptest.TestRunner(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -95,24 +97,21 @@ func TestProject_errorWithExchange(t *testing.T) {
 	infinityRunner := &infinityRunner{}
 
 	port := ":5551"
-	dist := mockPeer(t, port)
+	dist := eptest.NewPeer(t, port)
 	defer dist.Close()
 
 	port2 := ":5552"
+	peer2 := eptest.NewPeer(t, port)
+	defer peer2.Close()
 
-	ctx := context.WithValue(context.Background(), distributerKey, dist)
-	ctx = context.WithValue(ctx, allNodesKey, []string{port, port2, ":5553"})
-	ctx = context.WithValue(ctx, masterNodeKey, port)
-	ctx = context.WithValue(ctx, thisNodeKey, port)
-
-	exchange := Scatter().(*exchange)
-
-	runner := Pipeline(
-		exchange,
-		Project(infinityRunner, &errRunner{err}),
+	runner := ep.Pipeline(
+		infinityRunner,
+		ep.Project(ep.Scatter(), &errRunner{err}),
 	)
-	data := NewDataset(Null.Data(1))
-	data, err = TestRunner(runner, data)
+	runner = dist.Distribute(runner, port, port2)
+
+	data := ep.NewDataset(ep.Null.Data(1))
+	data, err = eptest.TestRunner(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -125,12 +124,12 @@ func TestProject_nested_errorInFirstRunner(t *testing.T) {
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
 	infinityRunner3 := &infinityRunner{}
-	runner := Project(
-		Project(infinityRunner3, &errRunner{err}),
-		Project(infinityRunner1, infinityRunner2),
+	runner := ep.Project(
+		ep.Project(infinityRunner3, &errRunner{err}),
+		ep.Project(infinityRunner1, infinityRunner2),
 	)
-	data := NewDataset(Null.Data(1))
-	data, err = TestRunner(runner, data)
+	data := ep.NewDataset(ep.Null.Data(1))
+	data, err = eptest.TestRunner(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -145,12 +144,12 @@ func TestProject_nested_errorInSecondRunner(t *testing.T) {
 	infinityRunner1 := &infinityRunner{}
 	infinityRunner2 := &infinityRunner{}
 	infinityRunner3 := &infinityRunner{}
-	runner := Project(
-		Project(infinityRunner1, infinityRunner2),
-		Project(infinityRunner3, &errRunner{err}),
+	runner := ep.Project(
+		ep.Project(infinityRunner1, infinityRunner2),
+		ep.Project(infinityRunner3, &errRunner{err}),
 	)
-	data := NewDataset(Null.Data(1))
-	data, err = TestRunner(runner, data)
+	data := ep.NewDataset(ep.Null.Data(1))
+	data, err = eptest.TestRunner(runner, data)
 
 	require.Equal(t, 0, data.Width())
 	require.Error(t, err)
@@ -162,22 +161,22 @@ func TestProject_nested_errorInSecondRunner(t *testing.T) {
 
 // projected runners should return the same number of rows
 func TestProject_errorMismatchRows(t *testing.T) {
-	runner := Project(&upper{}, &count{})
-	data := NewDataset(strs([]string{"hello", "world"}))
-	_, err := TestRunner(runner, data)
+	runner := ep.Project(&upper{}, &count{})
+	data := ep.NewDataset(strs([]string{"hello", "world"}))
+	_, err := eptest.TestRunner(runner, data)
 	require.Error(t, err)
-	require.Equal(t, errMismatch, err)
+	require.Equal(t, "mismatched number of rows", err.Error())
 }
 
 type count struct{}
 
-func (*count) Returns() []Type { return []Type{str} }
-func (*count) Run(_ context.Context, inp, out chan Dataset) error {
+func (*count) Returns() []ep.Type { return []ep.Type{str} }
+func (*count) Run(_ context.Context, inp, out chan ep.Dataset) error {
 	c := 0
 	for data := range inp {
 		c += data.Len()
 	}
 
-	out <- NewDataset(strs{fmt.Sprintf("%d", c)})
+	out <- ep.NewDataset(strs{fmt.Sprintf("%d", c)})
 	return nil
 }

--- a/rows_test.go
+++ b/rows_test.go
@@ -1,17 +1,18 @@
-package ep
+package ep_test
 
 import (
 	"context"
 	"database/sql/driver"
+	"github.com/panoplyio/ep"
 	"github.com/stretchr/testify/require"
 	"io"
 	"testing"
 )
 
 func TestRows(t *testing.T) {
-	data := NewDataset(strs([]string{"hello", "world"}))
-	runner := Pipeline(&dataRunner{Dataset: data}, &upper{})
-	rows := Rows(context.Background(), runner).(driver.Rows)
+	data := ep.NewDataset(strs([]string{"hello", "world"}))
+	runner := ep.Pipeline(&dataRunner{Dataset: data}, &upper{})
+	rows := ep.Rows(context.Background(), runner).(driver.Rows)
 	cols := rows.Columns()
 	require.Equal(t, 1, len(cols))
 	require.Equal(t, "upper", cols[0])

--- a/runner_example_test.go
+++ b/runner_example_test.go
@@ -9,7 +9,7 @@ import (
 func ExampleRunner() {
 	upper := &upper{}
 	data := ep.NewDataset(strs([]string{"hello", "world"}))
-	data, err := eptest.TestRunner(upper, data)
+	data, err := eptest.Run(upper, data)
 	fmt.Println(data.Strings(), err)
 
 	// Output:

--- a/runner_example_test.go
+++ b/runner_example_test.go
@@ -1,53 +1,15 @@
-package ep
+package ep_test
 
 import (
-	"context"
 	"fmt"
-	"strings"
+	"github.com/panoplyio/ep"
+	"github.com/panoplyio/ep/eptest"
 )
-
-type upper struct{}
-
-func (*upper) Returns() []Type { return []Type{SetAlias(str, "upper")} }
-func (*upper) Run(_ context.Context, inp, out chan Dataset) error {
-	for data := range inp {
-		if data.At(0).Type() == Null {
-			out <- data
-			continue
-		}
-
-		res := make(strs, data.Len())
-		for i, v := range data.At(0).(strs) {
-			res[i] = strings.ToUpper(v)
-		}
-		out <- NewDataset(res)
-	}
-	return nil
-}
-
-type question struct{}
-
-func (*question) Returns() []Type { return []Type{SetAlias(str, "question")} }
-func (*question) Run(_ context.Context, inp, out chan Dataset) error {
-	for data := range inp {
-		if data.At(0).Type() == Null {
-			out <- data
-			continue
-		}
-
-		res := make(strs, data.Len())
-		for i, v := range data.At(0).(strs) {
-			res[i] = "is " + v + "?"
-		}
-		out <- NewDataset(res)
-	}
-	return nil
-}
 
 func ExampleRunner() {
 	upper := &upper{}
-	data := NewDataset(strs([]string{"hello", "world"}))
-	data, err := TestRunner(upper, data)
+	data := ep.NewDataset(strs([]string{"hello", "world"}))
+	data, err := eptest.TestRunner(upper, data)
 	fmt.Println(data.Strings(), err)
 
 	// Output:

--- a/union_example_test.go
+++ b/union_example_test.go
@@ -1,13 +1,15 @@
-package ep
+package ep_test
 
 import (
 	"fmt"
+	"github.com/panoplyio/ep"
+	"github.com/panoplyio/ep/eptest"
 )
 
 func ExampleUnion() {
-	runner, _ := Union(&upper{}, &question{})
-	data := NewDataset(strs([]string{"hello", "world"}))
-	data, err := TestRunner(runner, data)
+	runner, _ := ep.Union(&upper{}, &question{})
+	data := ep.NewDataset(strs([]string{"hello", "world"}))
+	data, err := eptest.TestRunner(runner, data)
 	fmt.Println(data.Strings(), err)
 
 	// Output:

--- a/union_example_test.go
+++ b/union_example_test.go
@@ -9,7 +9,7 @@ import (
 func ExampleUnion() {
 	runner, _ := ep.Union(&upper{}, &question{})
 	data := ep.NewDataset(strs([]string{"hello", "world"}))
-	data, err := eptest.TestRunner(runner, data)
+	data, err := eptest.Run(runner, data)
 	fmt.Println(data.Strings(), err)
 
 	// Output:


### PR DESCRIPTION
Currently ep exposes some tests utils functions, that shouldn't be used from production code. Therefore, we would like to move public tests utilities to other package.
The convention in go for that case is to expose other package ends with `test` for utilities only (not actual tests, just utilities).

- ep tests should still be located in ep_test (public) ep (private). see pipeline_test vs. pipeline_internal_test
- test **utilities** that are used by ep_test, epsilon, or any other ep user - should be located in eptest package

This PR also contains:
- solve exchange deadlock (see [comment](https://github.com/panoplyio/ep/pull/58/files?diff=unified#diff-e3fccc860d65cb2b1ea65ef992358a08R95))
- modify TestProject_errorWithExchange to actually test exchange within project and pipline