### PR TITLE
Remove Partition function

### DIFF
--- a/data.go
+++ b/data.go
@@ -62,27 +62,3 @@ func Cut(data Data, cutpoints ...int) Data {
 
 	return NewDataset(res...)
 }
-
-// Partition the Data into several sub-segments such that each segment contains
-// the same value, repeated multiple times. Dataset also implements the Data
-// interface is a valid input to this function.
-//
-// NOTE that partitioning will re-order the data to create the minimum number of
-// batches. Thus is does not maintain order
-func Partition(data Data) Data {
-	sort.Sort(data)
-	var last string
-	var cutpoints []int
-	for i, s := range data.Strings() {
-		if i == 0 {
-			last = s
-		}
-
-		if last != s {
-			cutpoints = append(cutpoints, i)
-			last = s
-		}
-	}
-
-	return Cut(data, cutpoints...)
-}

--- a/data_utils_example_test.go
+++ b/data_utils_example_test.go
@@ -27,12 +27,3 @@ func ExampleCut() {
 	// Output:
 	// [[hello] [world foo] [bar]]
 }
-
-func ExamplePartition() {
-	var d ep.Data = strs([]string{"hello", "world", "hello", "bar"})
-	data := ep.Partition(d)
-	fmt.Println(data.Strings())
-
-	// Output:
-	// [[bar] [hello hello] [world]]
-}


### PR DESCRIPTION
As requested in #62, this PR removes `Partition` function since it is not used and not needed anywhere. The name `Partition` will be assigned to another function that creates a partition exchange runner (#62)