### PR TITLE
Allow exchange runners to run (short-circuted) locally

### DIFF
--- a/exchange.go
+++ b/exchange.go
@@ -73,16 +73,6 @@ type exchange struct {
 
 func (ex *exchange) Returns() []Type { return []Type{Wildcard} }
 func (ex *exchange) Run(ctx context.Context, inp, out chan Dataset) (err error) {
-	if ex.inited {
-		// exchanged uses a predefined UID and connection listeners on all of
-		// the nodes. Running it again would conflict with the existing UID,
-		// leading to de-synchronization between the nodes. Thus it's not
-		// currently supported. TODO: reconsider this architecture? Perhaps
-		// we can distribute the exchange upon Run()?
-		return fmt.Errorf("exhcnage cannot be Run() more than once")
-	}
-
-	ex.inited = true
 	defer func() {
 		closeErr := ex.Close()
 		// prefer real existing error over close error
@@ -301,6 +291,7 @@ func (ex *exchange) decodeNext() (Dataset, error) {
 
 // init initializes the connections, encoders & decoders
 func (ex *exchange) init(ctx context.Context) (err error) {
+
 	// hashRing handles partitioning between nodes
 	ex.hashRing = consistent.New()
 
@@ -320,8 +311,16 @@ func (ex *exchange) init(ctx context.Context) (err error) {
 		// no distributer was defined - so it's only running locally. We can
 		// short-circuit the whole thing
 		allNodes = []string{""}
+	} else if ex.inited {
+		// exchanged uses a predefined UID and connection listeners on all of
+		// the nodes. Running it again would conflict with the existing UID,
+		// leading to de-synchronization between the nodes. Thus it's not
+		// currently supported. TODO: reconsider this architecture? Perhaps
+		// we can distribute the exchange upon Run()?
+		return fmt.Errorf("exhcnage cannot be Run() more than once")
 	}
 
+	ex.inited = true
 	targetNodes := allNodes
 	if ex.Type == gather {
 		targetNodes = []string{masterNode}

--- a/exchange.go
+++ b/exchange.go
@@ -309,17 +309,18 @@ func (ex *exchange) init(ctx context.Context) (err error) {
 	// By using a map we can find an encoder for every address
 	ex.encsByKey = make(map[string]encoder)
 
+	allNodes, _ := ctx.Value(allNodesKey).([]string)
+	thisNode, _ := ctx.Value(thisNodeKey).(string)
+	masterNode, _ := ctx.Value(masterNodeKey).(string)
 	dist, _ := ctx.Value(distributerKey).(interface {
 		Connect(addr, uid string) (net.Conn, error)
 	})
 
 	if dist == nil {
-		return fmt.Errorf("exhcnage started without a distributer")
+		// no distributer was defined - so it's only running locally. We can
+		// short-circuit the whole thing
+		allNodes = []string{""}
 	}
-
-	allNodes := ctx.Value(allNodesKey).([]string)
-	thisNode := ctx.Value(thisNodeKey).(string)
-	masterNode := ctx.Value(masterNodeKey).(string)
 
 	targetNodes := allNodes
 	if ex.Type == gather {

--- a/exchange.go
+++ b/exchange.go
@@ -310,7 +310,7 @@ func (ex *exchange) init(ctx context.Context) (err error) {
 	if dist == nil {
 		// no distributer was defined - so it's only running locally. We can
 		// short-circuit the whole thing
-		allNodes = []string{""}
+		allNodes = []string{thisNode}
 	} else if ex.inited {
 		// exchanged uses a predefined UID and connection listeners on all of
 		// the nodes. Running it again would conflict with the existing UID,

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -241,20 +241,20 @@ func TestExchange_undistributed(t *testing.T) {
 	data, err := eptest.Run(ep.Scatter(), data)
 	require.NoError(t, err)
 	require.NotNil(t, data)
-	require.Equal(t, []string{"[hello world]"}, data.Strings())
+	require.Equal(t, []string{"(hello)", "(world)"}, data.Strings())
 
 	data, err = eptest.Run(ep.Broadcast(), data)
 	require.NoError(t, err)
 	require.NotNil(t, data)
-	require.Equal(t, []string{"[hello world]"}, data.Strings())
+	require.Equal(t, []string{"(hello)", "(world)"}, data.Strings())
 
 	data, err = eptest.Run(ep.Gather(), data)
 	require.NoError(t, err)
 	require.NotNil(t, data)
-	require.Equal(t, []string{"[hello world]"}, data.Strings())
+	require.Equal(t, []string{"(hello)", "(world)"}, data.Strings())
 
 	data, err = eptest.Run(ep.Partition(0), data)
 	require.NoError(t, err)
 	require.NotNil(t, data)
-	require.Equal(t, []string{"[hello world]"}, data.Strings())
+	require.Equal(t, []string{"(hello)", "(world)"}, data.Strings())
 }

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -233,3 +233,24 @@ func TestPartition_sendsCompleteDatasets(t *testing.T) {
 	require.Equal(t, 2, sizes.Len())
 	require.ElementsMatch(t, expected, sizes.Strings())
 }
+
+// test that exchange runners act as passthrough when executed without a
+// distributer
+func TestExchange_undistributed(t *testing.T) {
+	data := ep.NewDataset(strs{"hello", "world"})
+	data, err := eptest.Run(ep.Scatter(), data)
+	require.NoError(t, err)
+	require.Equal(t, []string{"[hello world]"}, data.Strings())
+
+	data, err = eptest.Run(ep.Broadcast(), data)
+	require.NoError(t, err)
+	require.Equal(t, []string{"[hello world]"}, data.Strings())
+
+	data, err = eptest.Run(ep.Gather(), data)
+	require.NoError(t, err)
+	require.Equal(t, []string{"[hello world]"}, data.Strings())
+
+	data, err = eptest.Run(ep.Partition(0), data)
+	require.NoError(t, err)
+	require.Equal(t, []string{"[hello world]"}, data.Strings())
+}

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -240,17 +240,21 @@ func TestExchange_undistributed(t *testing.T) {
 	data := ep.NewDataset(strs{"hello", "world"})
 	data, err := eptest.Run(ep.Scatter(), data)
 	require.NoError(t, err)
+	require.NotNil(t, data)
 	require.Equal(t, []string{"[hello world]"}, data.Strings())
 
 	data, err = eptest.Run(ep.Broadcast(), data)
 	require.NoError(t, err)
+	require.NotNil(t, data)
 	require.Equal(t, []string{"[hello world]"}, data.Strings())
 
 	data, err = eptest.Run(ep.Gather(), data)
 	require.NoError(t, err)
+	require.NotNil(t, data)
 	require.Equal(t, []string{"[hello world]"}, data.Strings())
 
 	data, err = eptest.Run(ep.Partition(0), data)
 	require.NoError(t, err)
+	require.NotNil(t, data)
 	require.Equal(t, []string{"[hello world]"}, data.Strings())
 }


### PR DESCRIPTION
When there's no distributer.

This is useful for tests or generic code (like in `ep-join`) where the exchange runners can be used (Scatter, Gather, etc.), yet the whole operation doesn't necessarily distributes the runner via a Distributer.