### PR TITLE
Disallow running exchange repeatedly (even locally)

### DIFF
--- a/exchange.go
+++ b/exchange.go
@@ -311,12 +311,17 @@ func (ex *exchange) init(ctx context.Context) (err error) {
 		// no distributer was defined - so it's only running locally. We can
 		// short-circuit the whole thing
 		allNodes = []string{thisNode}
-	} else if ex.inited {
+	}
+
+	if ex.inited {
 		// exchanged uses a predefined UID and connection listeners on all of
 		// the nodes. Running it again would conflict with the existing UID,
 		// leading to de-synchronization between the nodes. Thus it's not
 		// currently supported. TODO: reconsider this architecture? Perhaps
 		// we can distribute the exchange upon Run()?
+		// NOTE that while it's possible to run exchange multiple times locally,
+		// it's disabled here to guanratee that runners behave locally as they
+		// do distributed.
 		return fmt.Errorf("exhcnage cannot be Run() more than once")
 	}
 


### PR DESCRIPTION
Currently exchange runners can't run more than once. It's a silly limitation that's easy to solve (with a per-query uid and reinitialization in the init() function - I can explain further...), but in #80 I introduced a change that allowed local exchange runners to run more than once (resulting in a weird panic later). We should really address this, but in the meantime I'm fixing it with the same test that's currently used for distributed queries.