### PR TITLE
support record in NewDatasetLike

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -55,18 +55,25 @@ func NewDataset(data ...Data) Dataset {
 func NewDatasetLike(sample Dataset, size int) Dataset {
 	res := make([]Data, sample.Width())
 	for i := range res {
-		res[i] = sample.At(i).Type().Data(size)
+		col := sample.At(i)
+		if col.Type().Name() == Record.Name() {
+			res[i] = NewDatasetLike(col.(Dataset), size)
+		} else {
+			res[i] = col.Type().Data(size)
+		}
 	}
 	return NewDataset(res...)
 }
 
 // NewDatasetTypes creates a new Data object at the provided size and types
 func NewDatasetTypes(types []Type, size int) Dataset {
-	data := make([]Data, len(types))
+	res := make([]Data, len(types))
 	for i, t := range types {
-		data[i] = t.Data(size)
+		if t.Name() != Record.Name() {
+			res[i] = t.Data(size)
+		}
 	}
-	return NewDataset(data...)
+	return NewDataset(res...)
 }
 
 // Width of the dataset (number of columns)

--- a/dataset.go
+++ b/dataset.go
@@ -69,9 +69,10 @@ func NewDatasetLike(sample Dataset, size int) Dataset {
 func NewDatasetTypes(types []Type, size int) Dataset {
 	res := make([]Data, len(types))
 	for i, t := range types {
-		if t.Name() != Record.Name() {
-			res[i] = t.Data(size)
+		if t.Name() == Record.Name() {
+			panic("NewDatasetTypes invalid call - only concrete types are allowed")
 		}
+		res[i] = t.Data(size)
 	}
 	return NewDataset(res...)
 }

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -24,6 +24,34 @@ func ExampleDataset_Duplicate() {
 	// [hello world]
 }
 
+func TestNewDatasetLike(t *testing.T) {
+	recordsColumn := ep.NewDataset(ep.Null.Data(2))
+	data := ep.NewDataset(strs([]string{"hello", "world"}), ep.Null.Data(2), recordsColumn)
+	data2 := ep.NewDatasetLike(data, 10)
+
+	require.Equal(t, 3, data2.Width())
+	require.Equal(t, 10, data2.Len())
+	require.Equal(t, str, data2.At(0).Type())
+	require.Equal(t, ep.Null, data2.At(1).Type())
+	require.Equal(t, "(,,())", data2.Strings()[0])
+}
+
+func TestNewDatasetTypes(t *testing.T) {
+	data := ep.NewDatasetTypes([]ep.Type{str, ep.Null}, 10)
+
+	require.Equal(t, 2, data.Width())
+	require.Equal(t, 10, data.Len())
+	require.Equal(t, str, data.At(0).Type())
+	require.Equal(t, ep.Null, data.At(1).Type())
+	require.Equal(t, "(,)", data.Strings()[0])
+}
+
+func TestNewDatasetTypes_panicWithRecords(t *testing.T) {
+	require.Panics(t, func() {
+		ep.NewDatasetTypes([]ep.Type{str, ep.Record, ep.Null}, 10)
+	})
+}
+
 func TestDatasetInvariant(t *testing.T) {
 	d1 := strs([]string{"1", "2", "4", "0", "3", "1", "1"})
 	d2 := strs([]string{"a", "b", "c", "", "e", "f", "g"})


### PR DESCRIPTION
record/dataset can not be created without concrete types.
this pr allows sending records to the util functions `NewDatasetLike` and `NewDatasetTypes`