### PR TITLE
Add Args() to pipeline runner

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -107,6 +107,17 @@ func (rs pipeline) Returns() []Type {
 	return rs.returnsOne(len(rs) - 1) // start with the last one.
 }
 
+// Args returns the arguments expected by the first runner in this pipeline.
+// If that runner is an instance of RunnerArgs, its Args() result will be returned.
+// Otherwise, Wildcard type is returned.
+func (rs pipeline) Args() []Type {
+	runnerArgs, ok := rs[0].(RunnerArgs)
+	if ok {
+		return runnerArgs.Args()
+	}
+	return []Type{Wildcard}
+}
+
 func (rs pipeline) returnsOne(j int) []Type {
 	res := rs[j].Returns()
 	if j == 0 {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -171,6 +171,28 @@ func TestPipeline_Returns_wildcardMinusTail(t *testing.T) {
 	require.Equal(t, "upper", ep.GetAlias(types[0]))
 }
 
+func TestPipeline_Args_runnerArgs(t *testing.T) {
+	// two runners are required to create an instance of pipeline
+	runner := ep.Pipeline(&runnerWithArgs{}, &runnerWithoutArgs{})
+
+	runnerArgs, ok := runner.(ep.RunnerArgs)
+	require.True(t, ok)
+
+	args := runnerArgs.Args()
+	require.Equal(t, []ep.Type{ep.Any}, args)
+}
+
+func TestPipeline_Args_noArgs(t *testing.T) {
+	// two runners are required to create an instance of pipeline
+	runner := ep.Pipeline(&runnerWithoutArgs{}, &runnerWithArgs{})
+
+	runnerArgs, ok := runner.(ep.RunnerArgs)
+	require.True(t, ok)
+
+	args := runnerArgs.Args()
+	require.Equal(t, []ep.Type{ep.Wildcard}, args)
+}
+
 type tailCutter struct {
 	CutFromTail int
 }
@@ -182,3 +204,9 @@ func (*tailCutter) Run(_ context.Context, inp, out chan ep.Dataset) error {
 	}
 	return nil
 }
+
+type runnerWithArgs struct{ ep.Runner }
+
+func (r *runnerWithArgs) Args() []ep.Type { return []ep.Type{ep.Any} }
+
+type runnerWithoutArgs struct{ ep.Runner }


### PR DESCRIPTION
This PR adds `Args` implementation to `pipeline`. From this point, we will be able to cast pipelines to `RunnerArgs` when needed. Pipelines will use the first runner to determine the result of `Args`. If the first runner in a pipeline will not implement `RunnerArgs` itself, the cast might fail due to `Pipeline` constructor optimizations (not every `Pipeline()` call results in a new instance of `pipeline` struct).