### PR TITLE
Fix passThrough filtering in pipeline

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -29,8 +29,7 @@ func Pipeline(runners ...Runner) Runner {
 	// filter out passThrough runners as they don't affect the pipe
 	filtered := flat[:0]
 	for _, r := range flat {
-		_, isPassThrough := r.(*passThrough)
-		if !isPassThrough {
+		if r != passThroughSingleton {
 			filtered = append(filtered, r)
 		}
 	}


### PR DESCRIPTION
[Task](https://app.asana.com/0/573768021211412/499296949137123/f)

Since `passthrough` can now include types, we should only filter it when it is a singleton instance that is the same every time.