### PR TITLE
Register keys as well as values with gob

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -91,7 +91,7 @@ type runnersReg map[interface{}][]Runner
 // Register a key-runner pair to be globally accessible via the Get() function
 // using the same key.
 func (reg runnersReg) Register(k interface{}, r Runner) runnersReg {
-	registerGob(r)
+	registerGob(k, r)
 	k = registryKey(k)
 	reg[k] = append(reg[k], r)
 	return reg


### PR DESCRIPTION
This change is required to support gob encoding of complete AST nodes.