### PR TITLE
Support multiple cols in Partition

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -300,7 +300,8 @@ func (set dataset) Strings() []string {
 	return res
 }
 
-// ColumnStrings returns string values of selected columns of a provided dataset
+// ColumnStrings returns string values of selected columns of a provided dataset.
+// If no columns provided, all columns are used
 func ColumnStrings(set Dataset, cols ...int) [][]string {
 	if len(cols) == 0 {
 		cols = make([]int, set.Width())

--- a/dataset.go
+++ b/dataset.go
@@ -28,12 +28,6 @@ type Dataset interface {
 	// Split divides dataset to two parts, where the second part width determined by
 	// the given secondWidth argument
 	Split(secondWidth int) (Dataset, Dataset)
-
-	// ColumnStrings returns the string representation of selected columns
-	// in this dataset as a slice of columns, each having a slice of rows.
-	// If no specific columns are provided (called with no args), all columns
-	// are returned
-	ColumnStrings(cols ...int) [][]string
 }
 
 // Record is exposed data type similar to postgres' record, implements Type
@@ -121,22 +115,6 @@ func (set dataset) Split(secondWidth int) (Dataset, Dataset) {
 	}
 	firstWidth := set.Width() - secondWidth
 	return set[:firstWidth], set[firstWidth:]
-}
-
-// ColumnStrings returns string values of selected columns of this dataset
-func (set dataset) ColumnStrings(cols ...int) [][]string {
-	if len(cols) == 0 {
-		cols = make([]int, set.Width())
-		for i := 0; i < set.Width(); i++ {
-			cols[i] = i
-		}
-	}
-
-	stringValues := make([][]string, len(cols))
-	for i, col := range cols {
-		stringValues[i] = set.At(col).Strings()
-	}
-	return stringValues
 }
 
 // see Data.Type
@@ -320,4 +298,20 @@ func (set dataset) Strings() []string {
 		res[i] = "(" + s[:len(s)-1] + ")"
 	}
 	return res
+}
+
+// ColumnStrings returns string values of selected columns of a provided dataset
+func ColumnStrings(set Dataset, cols ...int) [][]string {
+	if len(cols) == 0 {
+		cols = make([]int, set.Width())
+		for i := 0; i < set.Width(); i++ {
+			cols[i] = i
+		}
+	}
+
+	stringValues := make([][]string, len(cols))
+	for i, col := range cols {
+		stringValues[i] = set.At(col).Strings()
+	}
+	return stringValues
 }

--- a/dataset.go
+++ b/dataset.go
@@ -29,9 +29,11 @@ type Dataset interface {
 	// the given secondWidth argument
 	Split(secondWidth int) (Dataset, Dataset)
 
-	// ColumnStrings returns the string representation of all columns in this dataset
-	// as a slice of columns, each having a slice of rows
-	ColumnStrings() [][]string
+	// ColumnStrings returns the string representation of selected columns
+	// in this dataset as a slice of columns, each having a slice of rows.
+	// If no specific columns are provided (called with no args), all columns
+	// are returned
+	ColumnStrings(cols ...int) [][]string
 }
 
 // Record is exposed data type similar to postgres' record, implements Type
@@ -121,11 +123,18 @@ func (set dataset) Split(secondWidth int) (Dataset, Dataset) {
 	return set[:firstWidth], set[firstWidth:]
 }
 
-// ColumnStrings returns string values of this entire dataset
-func (set dataset) ColumnStrings() [][]string {
-	stringValues := make([][]string, set.Width())
-	for i := 0; i < set.Width(); i++ {
-		stringValues[i] = set.At(i).Strings()
+// ColumnStrings returns string values of selected columns of this dataset
+func (set dataset) ColumnStrings(cols ...int) [][]string {
+	if len(cols) == 0 {
+		cols = make([]int, set.Width())
+		for i := 0; i < set.Width(); i++ {
+			cols[i] = i
+		}
+	}
+
+	stringValues := make([][]string, len(cols))
+	for i, col := range cols {
+		stringValues[i] = set.At(col).Strings()
 	}
 	return stringValues
 }

--- a/dataset.go
+++ b/dataset.go
@@ -28,6 +28,10 @@ type Dataset interface {
 	// Split divides dataset to two parts, where the second part width determined by
 	// the given secondWidth argument
 	Split(secondWidth int) (Dataset, Dataset)
+
+	// ColumnStrings returns the string representation of all columns in this dataset
+	// as a slice of columns, each having a slice of rows
+	ColumnStrings() [][]string
 }
 
 // Record is exposed data type similar to postgres' record, implements Type
@@ -115,6 +119,15 @@ func (set dataset) Split(secondWidth int) (Dataset, Dataset) {
 	}
 	firstWidth := set.Width() - secondWidth
 	return set[:firstWidth], set[firstWidth:]
+}
+
+// ColumnStrings returns string values of this entire dataset
+func (set dataset) ColumnStrings() [][]string {
+	stringValues := make([][]string, set.Width())
+	for i := 0; i < set.Width(); i++ {
+		stringValues[i] = set.At(i).Strings()
+	}
+	return stringValues
 }
 
 // see Data.Type

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -143,3 +143,11 @@ func TestDataset_Strings(t *testing.T) {
 	dataset := ep.NewDataset(d1, d2)
 	require.EqualValues(t, expected, dataset.Strings())
 }
+
+func TestDataset_ColumnStrings(t *testing.T) {
+	d1 := strs([]string{"1", "2", "4", "0", "3", "1", "1"})
+	d2 := strs([]string{"a", "b", "c", "", "e", "f", "g"})
+	dataset := ep.NewDataset(d1, d2)
+
+	require.EqualValues(t, [][]string{d1, d2}, dataset.ColumnStrings())
+}

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -144,24 +144,24 @@ func TestDataset_Strings(t *testing.T) {
 	require.EqualValues(t, expected, dataset.Strings())
 }
 
-func TestDataset_ColumnStrings(t *testing.T) {
+func TestColumnStrings(t *testing.T) {
 	d1 := strs([]string{"1", "2", "4", "0", "3", "1", "1"})
 	d2 := strs([]string{"a", "b", "c", "", "e", "f", "g"})
 	dataset := ep.NewDataset(d1, d2)
 
 	t.Run("AllColumns", func(t *testing.T) {
-		require.EqualValues(t, [][]string{d1, d2}, dataset.ColumnStrings())
+		require.EqualValues(t, [][]string{d1, d2}, ep.ColumnStrings(dataset))
 	})
 
 	t.Run("FirstColumn", func(t *testing.T) {
-		require.EqualValues(t, [][]string{d1}, dataset.ColumnStrings(0))
+		require.EqualValues(t, [][]string{d1}, ep.ColumnStrings(dataset, 0))
 	})
 
 	t.Run("SecondColumn", func(t *testing.T) {
-		require.EqualValues(t, [][]string{d2}, dataset.ColumnStrings(1))
+		require.EqualValues(t, [][]string{d2}, ep.ColumnStrings(dataset, 1))
 	})
 
 	t.Run("BothColumns", func(t *testing.T) {
-		require.EqualValues(t, [][]string{d1, d2}, dataset.ColumnStrings(0, 1))
+		require.EqualValues(t, [][]string{d1, d2}, ep.ColumnStrings(dataset, 0, 1))
 	})
 }

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -149,5 +149,19 @@ func TestDataset_ColumnStrings(t *testing.T) {
 	d2 := strs([]string{"a", "b", "c", "", "e", "f", "g"})
 	dataset := ep.NewDataset(d1, d2)
 
-	require.EqualValues(t, [][]string{d1, d2}, dataset.ColumnStrings())
+	t.Run("AllColumns", func(t *testing.T) {
+		require.EqualValues(t, [][]string{d1, d2}, dataset.ColumnStrings())
+	})
+
+	t.Run("FirstColumn", func(t *testing.T) {
+		require.EqualValues(t, [][]string{d1}, dataset.ColumnStrings(0))
+	})
+
+	t.Run("SecondColumn", func(t *testing.T) {
+		require.EqualValues(t, [][]string{d2}, dataset.ColumnStrings(1))
+	})
+
+	t.Run("BothColumns", func(t *testing.T) {
+		require.EqualValues(t, [][]string{d1, d2}, dataset.ColumnStrings(0, 1))
+	})
 }

--- a/exchange.go
+++ b/exchange.go
@@ -276,7 +276,7 @@ func (ex *exchange) encodePartition(e interface{}) error {
 	}
 
 	ex.sortData(data)
-	stringValues := ex.getStringValues(data)
+	stringValues := data.ColumnStrings()
 
 	lastSeenHash := ex.getRowHash(stringValues, 0)
 	lastSlicedRow := 0

--- a/exchange.go
+++ b/exchange.go
@@ -52,7 +52,7 @@ func Broadcast() Runner {
 // will be used to find an appropriate endpoint for this data. Order not guaranteed
 func Partition(columns ...int) Runner {
 	uid, _ := uuid.NewV4()
-	return &exchange{UID: uid.String(), Type: partition, partitionCol: columns}
+	return &exchange{UID: uid.String(), Type: partition, PartitionCol: columns}
 }
 
 // exchange is a Runner that exchanges data between peer nodes
@@ -68,9 +68,9 @@ type exchange struct {
 	decsNext int         // Decoders Round Robin next index
 
 	// partition specific variables
+	PartitionCol []int                  // column indexes to use for partitioning
 	hashRing     *consistent.Consistent // hash ring for consistent hashing
 	encsByKey    map[string]encoder     // encoders mapped by key (node address)
-	partitionCol []int                  // column indexes to use for partitioning
 
 	// sortGather specific variables
 	SortingCols    []SortingCol // columns to sort by
@@ -305,9 +305,9 @@ func (ex *exchange) encodePartition(e interface{}) error {
 }
 
 func (ex *exchange) sortData(data Dataset) {
-	sortCols := make([]SortingCol, len(ex.partitionCol))
+	sortCols := make([]SortingCol, len(ex.PartitionCol))
 	for i := 0; i < len(sortCols); i++ {
-		sortCols[i] = SortingCol{Index: ex.partitionCol[i]}
+		sortCols[i] = SortingCol{Index: ex.PartitionCol[i]}
 	}
 	Sort(data, sortCols)
 }
@@ -322,7 +322,7 @@ func (ex *exchange) getStringValues(data Dataset) [][]string {
 
 func (ex *exchange) getRowHash(stringValues [][]string, row int) string {
 	var sb strings.Builder
-	for _, col := range ex.partitionCol {
+	for _, col := range ex.PartitionCol {
 		sb.WriteString(stringValues[col][row])
 	}
 	return sb.String()

--- a/exchange.go
+++ b/exchange.go
@@ -281,6 +281,7 @@ func (ex *exchange) encodePartition(e interface{}) error {
 		return fmt.Errorf("encodePartition called without a dataset")
 	}
 
+	// before partitioning data, sort it to generate larger batches
 	Sort(data, ex.PartitionCols)
 	stringValues := data.ColumnStrings()
 

--- a/exchange.go
+++ b/exchange.go
@@ -287,21 +287,18 @@ func (ex *exchange) encodePartition(e interface{}) error {
 		}
 
 		dataToEncode := data.Slice(lastSlicedRow, row)
-		lastSeenHash = hash
-		lastSlicedRow = row
-
-		err := ex.partitionData(dataToEncode, hash)
+		err := ex.partitionData(dataToEncode, lastSeenHash)
 		if err != nil {
 			return err
 		}
+
+		lastSeenHash = hash
+		lastSlicedRow = row
 	}
 
 	// leftover
-	if lastSlicedRow < data.Len() {
-		dataToEncode := data.Slice(lastSlicedRow, data.Len())
-		return ex.partitionData(dataToEncode, lastSeenHash)
-	}
-	return nil
+	dataToEncode := data.Slice(lastSlicedRow, data.Len())
+	return ex.partitionData(dataToEncode, lastSeenHash)
 }
 
 func (ex *exchange) sortData(data Dataset) {

--- a/exchange.go
+++ b/exchange.go
@@ -52,7 +52,6 @@ func Broadcast() Runner {
 // will be used to find an appropriate endpoint for this data. Order not guaranteed
 func Partition(columns ...int) Runner {
 	uid, _ := uuid.NewV4()
-
 	sortCols := make([]SortingCol, len(columns))
 	for i := 0; i < len(sortCols); i++ {
 		sortCols[i] = SortingCol{Index: columns[i]}

--- a/exchange.go
+++ b/exchange.go
@@ -290,7 +290,7 @@ func (ex *exchange) encodePartition(e interface{}) error {
 
 	// before partitioning data, sort it to generate larger batches
 	Sort(data, ex.SortingCols)
-	stringValues := data.ColumnStrings(ex.PartitionCols...)
+	stringValues := ColumnStrings(data, ex.PartitionCols...)
 
 	lastSeenHash := ex.getRowHash(stringValues, 0)
 	lastSlicedRow := 0

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -233,6 +233,8 @@ func TestPartition_usesMultipleColumns(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, firstRes)
+	require.Equal(t, 2, firstRes.Len())
+	require.Equal(t, []string{":5552", ":5551"}, firstRes.At(2).Strings())
 
 	// secondRes is partitioned by one col
 	runner = ep.Pipeline(ep.Partition(0), &nodeAddr{}, ep.Gather())
@@ -241,6 +243,8 @@ func TestPartition_usesMultipleColumns(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, secondRes)
+	require.Equal(t, 2, secondRes.Len())
+	require.Equal(t, []string{":5552", ":5552"}, secondRes.At(2).Strings())
 
 	// partition targets for the above input should be different
 	// when using different partition conditions

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -242,7 +242,7 @@ func TestPartition_usesMultipleColumns(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, secondRes)
 
-	// partition targets for teh above input should be different
+	// partition targets for the above input should be different
 	// when using different partition conditions
 	require.NotEqual(t, firstRes.At(2), secondRes.At(2))
 }

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -234,7 +234,6 @@ func TestPartition(t *testing.T) {
 		}
 
 		require.Equal(t, expectedOutput, res.Strings())
-
 	})
 }
 


### PR DESCRIPTION
This PR adds support for partitioning data based on multiple columns.

It also changes the way data is prepared for partitioning. Instead of slicing every row and keeping everything in memory grouped by encoder (connection), it is now sorts the data, and slices only complete chunks, which are sent to target nodes immediately.

Hashing in `getRowHash` does not have to be unique, it just has to be consistent: same data should end up on the same nodes.