### PR TITLE
propagate cancel error, without distribute it

### DIFF
--- a/distribute.go
+++ b/distribute.go
@@ -322,12 +322,15 @@ func (r *distRunner) Run(ctx context.Context, inp, out chan Dataset) error {
 	}()
 
 	var finalError error
-	if len(errs) > 0 {
-		finalError = errs[0]
+	for _, e := range errs {
+		if e != errProjectState && e != context.Canceled {
+			finalError = e
+			break
+		}
 	}
 	// wait for respErrs channel anyway, and select first meaningful error
 	for e := range respErrs {
-		if finalError == nil && e != errProjectState {
+		if finalError == nil && e != errProjectState && e != context.Canceled {
 			finalError = e
 		}
 	}

--- a/distribute.go
+++ b/distribute.go
@@ -323,14 +323,16 @@ func (r *distRunner) Run(ctx context.Context, inp, out chan Dataset) error {
 
 	var finalError error
 	for _, e := range errs {
-		if e != errProjectState && e != context.Canceled {
+		if e != context.Canceled {
 			finalError = e
-			break
+			if e != errProjectState {
+				break
+			}
 		}
 	}
 	// wait for respErrs channel anyway, and select first meaningful error
 	for e := range respErrs {
-		if finalError == nil && e != errProjectState && e != context.Canceled {
+		if (finalError == nil || finalError == errProjectState) && e != context.Canceled {
 			finalError = e
 		}
 	}

--- a/distribute_test.go
+++ b/distribute_test.go
@@ -95,8 +95,8 @@ func TestDistributer_Distribute_ignoreCanceledError(t *testing.T) {
 		name string
 		r    ep.Runner
 	}{
-		{name: "from peer", r: &dataRunner{ep.NewDataset(str.Data(1)), port2, true}},
-		{name: "from master", r: &dataRunner{ep.NewDataset(str.Data(1)), port1, true}},
+		{name: "from peer", r: &dataRunner{Dataset: ep.NewDataset(str.Data(1)), ThrowOnData: port2, ThrowCanceled: true}},
+		{name: "from master", r: &dataRunner{Dataset: ep.NewDataset(str.Data(1)), ThrowOnData: port1, ThrowCanceled: true}},
 	}
 
 	for _, tc := range tests {

--- a/distribute_test.go
+++ b/distribute_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func TestDistribute_success(t *testing.T) {
+func TestDistributer(t *testing.T) {
 	// avoid "bind: address already in use" error in future tests
 	defer time.Sleep(1 * time.Millisecond)
 
@@ -38,13 +38,13 @@ func TestDistribute_success(t *testing.T) {
 	require.Equal(t, "[hello world foo bar]", fmt.Sprintf("%v", data.At(0)))
 }
 
-func TestDistribute_connectionError(t *testing.T) {
+func TestDistributer_connectionError(t *testing.T) {
 	// avoid "bind: address already in use" error in future tests
 	defer time.Sleep(1 * time.Millisecond)
 
 	port1 := ":5551"
 	dist1 := eptest.NewPeer(t, port1)
-	defer require.NoError(t, dist1.Close())
+	defer func() { require.NoError(t, dist1.Close()) }()
 
 	runner := dist1.Distribute(&upper{}, port1, ":5000")
 
@@ -56,8 +56,7 @@ func TestDistribute_connectionError(t *testing.T) {
 }
 
 // Test that errors are transmitted across the network
-func TestDistributeErrorFromPeer(t *testing.T) {
-	t.Skip("TODO")
+func TestDistributer_Distribute_errorFromPeer(t *testing.T) {
 	port1 := ":5551"
 	dist1 := eptest.NewPeer(t, port1)
 
@@ -68,7 +67,7 @@ func TestDistributeErrorFromPeer(t *testing.T) {
 		require.NoError(t, peer.Close())
 	}()
 
-	mightErrored := &dataRunner{ep.NewDataset(), port2}
+	mightErrored := &dataRunner{Dataset: ep.NewDataset(), ThrowOnData: port2}
 	runner := ep.Pipeline(ep.Scatter(), &nodeAddr{}, mightErrored)
 	runner = dist1.Distribute(runner, port1, port2)
 
@@ -79,4 +78,37 @@ func TestDistributeErrorFromPeer(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, "error :5552", err.Error())
 	require.Equal(t, 0, data.Width())
+}
+
+func TestDistributer_Distribute_ignoreCanceledError(t *testing.T) {
+	port1 := ":5551"
+	dist1 := eptest.NewPeer(t, port1)
+
+	port2 := ":5552"
+	peer := eptest.NewPeer(t, port2)
+	defer func() {
+		require.NoError(t, dist1.Close())
+		require.NoError(t, peer.Close())
+	}()
+
+	var tests = []struct {
+		name string
+		r    ep.Runner
+	}{
+		{name: "from peer", r: &dataRunner{ep.NewDataset(str.Data(1)), port2, true}},
+		{name: "from master", r: &dataRunner{ep.NewDataset(str.Data(1)), port1, true}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := ep.Pipeline(ep.Scatter(), &nodeAddr{}, tc.r)
+			runner = dist1.Distribute(runner, port1, port2)
+
+			data1 := ep.NewDataset(strs{"hello", "world"})
+			data2 := ep.NewDataset(strs{"foo", "bar"})
+
+			_, err := eptest.Run(runner, data1, data2)
+			require.NoError(t, err)
+		})
+	}
 }

--- a/project_test.go
+++ b/project_test.go
@@ -103,7 +103,7 @@ func TestProject_errorWithExchange(t *testing.T) {
 	}()
 
 	infinityRunner := &infinityRunner{}
-	mightErrored := &dataRunner{ep.NewDataset(str.Data(1)), port2}
+	mightErrored := &dataRunner{Dataset: ep.NewDataset(str.Data(1)), ThrowOnData: port2}
 	runner := ep.Pipeline(
 		infinityRunner,
 		ep.Scatter(),


### PR DESCRIPTION
This PR ignore cancel error and doesn't distribute it across the cluster.
cancel error can be thrown when query was canceled on purpose or when a runner is done before its preceding.