### PR TITLE
Pipeline should hide cancel errors

### DIFF
--- a/distribute.go
+++ b/distribute.go
@@ -332,7 +332,7 @@ func (r *distRunner) Run(ctx context.Context, inp, out chan Dataset) error {
 	}
 	// wait for respErrs channel anyway, and select first meaningful error
 	for e := range respErrs {
-		if (finalError == nil || finalError == errProjectState) && e != context.Canceled {
+		if finalError == nil || finalError == errProjectState {
 			finalError = e
 		}
 	}

--- a/ep_test.go
+++ b/ep_test.go
@@ -11,6 +11,7 @@ import (
 var _ = ep.Runners.
 	Register("errRunner", &errRunner{}).
 	Register("infinityRunner", &infinityRunner{}).
+	Register("fixedData", &fixedData{}).
 	Register("dataRunner", &dataRunner{}).
 	Register("nodeAddr", &nodeAddr{}).
 	Register("count", &count{}).
@@ -77,6 +78,22 @@ func (r *infinityRunner) Run(ctx context.Context, inp, out chan ep.Dataset) erro
 	}
 }
 
+type fixedData struct {
+	ep.Dataset
+}
+
+func (r *fixedData) Returns() []ep.Type {
+	var types []ep.Type
+	for i := 0; i < r.Dataset.Len(); i++ {
+		types = append(types, r.Dataset.At(i).Type())
+	}
+	return types
+}
+func (r *fixedData) Run(ctx context.Context, _, out chan ep.Dataset) (err error) {
+	out <- r.Dataset
+	return nil
+}
+
 type dataRunner struct {
 	ep.Dataset
 	// ThrowOnData is a condition for throwing error. in case the last column
@@ -102,8 +119,8 @@ func (r *dataRunner) Run(ctx context.Context, inp, out chan ep.Dataset) (err err
 		if r.ThrowOnData == data.At(data.Width() - 1).Strings()[0] {
 			return err
 		}
+		out <- r.Dataset
 	}
-	out <- r.Dataset
 	return nil
 }
 

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -136,6 +136,20 @@ func TestPipeline_errNestedPipelineWithProject(t *testing.T) {
 	require.Equal(t, false, infinityRunner3.IsRunning(), "Infinity go-routine leak")
 }
 
+func TestPipeline_ignoreCanceledError(t *testing.T) {
+	runner := ep.Pipeline(&dataRunner{Dataset: ep.NewDataset(str.Data(1)), ThrowOnData: "cancel", ThrowCanceled: true}, &count{})
+
+	data1 := ep.NewDataset(strs{"not cancel"})
+	data2 := ep.NewDataset(strs{"cancel"})
+	res, err := eptest.Run(runner, data1, data2)
+
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, 1, res.Width())
+	require.Equal(t, 1, res.Len())
+	require.Equal(t, []string{"(1)"}, res.Strings())
+}
+
 func TestPipeline_Returns_wildcard(t *testing.T) {
 	runner := ep.Project(&upper{}, &question{})
 	runner = ep.Pipeline(runner, ep.PassThrough())

--- a/project.go
+++ b/project.go
@@ -79,9 +79,11 @@ func (rs project) Run(origCtx context.Context, inp, out chan Dataset) (err error
 		wg.Wait()
 		// choose first error out from all errors, that isn't project internal error
 		for _, errI := range errs {
-			if errI != nil && errI.Error() != errProjectState.Error() {
+			if (err == nil || err == errProjectState) && errI != nil {
 				err = errI
-				break
+				if err != errProjectState {
+					break
+				}
 			}
 		}
 	}()
@@ -181,9 +183,7 @@ func (rs project) Run(origCtx context.Context, inp, out chan Dataset) (err error
 			return // all done
 		}
 
-		if err == nil {
-			out <- result
-		}
+		out <- result
 
 		if allDummies {
 			return

--- a/rows_test.go
+++ b/rows_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestRows(t *testing.T) {
 	data := ep.NewDataset(strs([]string{"hello", "world"}))
-	runner := ep.Pipeline(&dataRunner{Dataset: data}, &upper{})
+	runner := ep.Pipeline(&fixedData{Dataset: data}, &upper{})
 	rows := ep.Rows(context.Background(), runner).(driver.Rows)
 	cols := rows.Columns()
 	require.Equal(t, 1, len(cols))


### PR DESCRIPTION
Pipeline should not propagate cancel error.
in case one of pipeline runners got cancel - cancel other runners and return.
wrapping project/pipeline will treat it as any other termination of runner 