### PR TITLE
 close pipeline in case of cancel

### DIFF
--- a/dataset_test.go
+++ b/dataset_test.go
@@ -89,7 +89,7 @@ func TestDataset_sortDescending(t *testing.T) {
 	dataset := ep.NewDataset(d1, d2, d3)
 
 	sort.Sort(sort.Reverse(dataset))
-	require.EqualValues(t, expected, dataset.Strings())
+	require.Equal(t, expected, dataset.Strings())
 }
 
 func TestDataset_LessOther_breakOnFirstColumn(t *testing.T) {
@@ -141,7 +141,7 @@ func TestDataset_Strings(t *testing.T) {
 	d2 := strs([]string{"a", "b", "c", "", "e", "f", "g"})
 
 	dataset := ep.NewDataset(d1, d2)
-	require.EqualValues(t, expected, dataset.Strings())
+	require.Equal(t, expected, dataset.Strings())
 }
 
 func TestColumnStrings(t *testing.T) {
@@ -150,18 +150,18 @@ func TestColumnStrings(t *testing.T) {
 	dataset := ep.NewDataset(d1, d2)
 
 	t.Run("AllColumns", func(t *testing.T) {
-		require.EqualValues(t, [][]string{d1, d2}, ep.ColumnStrings(dataset))
+		require.Equal(t, [][]string{d1, d2}, ep.ColumnStrings(dataset))
 	})
 
 	t.Run("FirstColumn", func(t *testing.T) {
-		require.EqualValues(t, [][]string{d1}, ep.ColumnStrings(dataset, 0))
+		require.Equal(t, [][]string{d1}, ep.ColumnStrings(dataset, 0))
 	})
 
 	t.Run("SecondColumn", func(t *testing.T) {
-		require.EqualValues(t, [][]string{d2}, ep.ColumnStrings(dataset, 1))
+		require.Equal(t, [][]string{d2}, ep.ColumnStrings(dataset, 1))
 	})
 
 	t.Run("BothColumns", func(t *testing.T) {
-		require.EqualValues(t, [][]string{d1, d2}, ep.ColumnStrings(dataset, 0, 1))
+		require.Equal(t, [][]string{d1, d2}, ep.ColumnStrings(dataset, 0, 1))
 	})
 }

--- a/distribute.go
+++ b/distribute.go
@@ -186,10 +186,7 @@ func (d *distributer) Serve(conn net.Conn) error {
 		// perhaps we want to log/return an error when some of the data is
 		// discarded here?
 		out := make(chan Dataset)
-		go func() {
-			for range out {
-			}
-		}()
+		go drain(out)
 
 		inp := make(chan Dataset, 1)
 		close(inp)

--- a/distribute.go
+++ b/distribute.go
@@ -191,7 +191,7 @@ func (d *distributer) Serve(conn net.Conn) error {
 		inp := make(chan Dataset, 1)
 		close(inp)
 
-		err = r.Run(context.Background(), inp, out)
+		Run(context.Background(), r, inp, out, nil, &err)
 		if err != nil {
 			err = &errMsg{err.Error()}
 		}

--- a/eptest/eptest.go
+++ b/eptest/eptest.go
@@ -19,10 +19,7 @@ func Run(r ep.Runner, datasets ...ep.Dataset) (ep.Dataset, error) {
 func RunWithContext(ctx context.Context, r ep.Runner, datasets ...ep.Dataset) (res ep.Dataset, err error) {
 	inp := make(chan ep.Dataset)
 	out := make(chan ep.Dataset)
-	go func() {
-		err = r.Run(ctx, inp, out)
-		close(out)
-	}()
+	go ep.Run(ctx, r, inp, out, nil, &err)
 
 	go func() {
 		for _, data := range datasets {

--- a/eptest/eptest.go
+++ b/eptest/eptest.go
@@ -72,10 +72,7 @@ func BenchWithContext(ctx context.Context, r ep.Runner, datasets ...ep.Dataset) 
 	}
 	close(inp)
 
-	go func() {
-		defer close(out)
-		err = r.Run(ctx, inp, out)
-	}()
+	go ep.Run(ctx, r, inp, out, nil, &err)
 
 	for range out {
 	}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/panoplyio/ep"
 	"github.com/panoplyio/ep/eptest"
 	"github.com/stretchr/testify/require"
+	"strconv"
 	"testing"
 )
 
@@ -155,7 +156,7 @@ func TestPipeline_multipleErrorsPropagation(t *testing.T) {
 	err := fmt.Errorf("something bad happened")
 
 	for errIdx := 0; errIdx < pipeLength; errIdx++ {
-		t.Run(fmt.Sprintf("first error in runner %d", errIdx), func(t *testing.T) {
+		t.Run(strconv.Itoa(errIdx), func(t *testing.T) {
 			runners := make([]ep.Runner, pipeLength)
 			for i := range runners {
 				if i == errIdx || i == (errIdx+2)%pipeLength {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -121,7 +121,7 @@ type runnerWithoutArgs struct{ ep.Runner }
 
 // errors handling
 func TestPipeline_errorPropagation(t *testing.T) {
-	pipeLength := 8
+	pipeLength := 4
 	err := fmt.Errorf("something bad happened")
 
 	for errIdx := 0; errIdx < pipeLength; errIdx++ {

--- a/project.go
+++ b/project.go
@@ -64,7 +64,7 @@ func (rs project) Filter(keep []bool) {
 
 // Run dispatches the same input to all inner runners, then collects and
 // joins their results into a single dataset output
-func (rs project) Run(origCtx context.Context, inp, out chan Dataset) (err error) {
+func (rs project) Run(ctx context.Context, inp, out chan Dataset) (err error) {
 	rs.useDummySingleton()
 	// set up the left and right channels
 	inps := make([]chan Dataset, len(rs))
@@ -83,7 +83,7 @@ func (rs project) Run(origCtx context.Context, inp, out chan Dataset) (err error
 		}
 	}()
 
-	ctx, cancel := context.WithCancel(origCtx)
+	ctx, cancel := context.WithCancel(ctx)
 
 	// run all runners in go-routines
 	for i := range rs {
@@ -115,7 +115,7 @@ func (rs project) Run(origCtx context.Context, inp, out chan Dataset) (err error
 
 		for {
 			select {
-			case <-ctx.Done(): // listen to both ctx and origCtx
+			case <-ctx.Done(): // listen to both new ctx and original ctx
 				cancel()
 				return
 			case data, ok := <-inp:

--- a/project.go
+++ b/project.go
@@ -189,7 +189,7 @@ func (rs project) useDummySingleton() {
 	}
 }
 
-// dummyRunnerSingleton is a runner that does nothing and just return immediately
+// dummyRunnerSingleton is a runner that does nothing and just returns immediately
 var dummyRunnerSingleton = &dummyRunner{}
 
 // variadicDummiesBatch is used for replacing unused columns

--- a/project.go
+++ b/project.go
@@ -93,12 +93,12 @@ func (rs project) Run(origCtx context.Context, inp, out chan Dataset) (err error
 		go func(idx int) {
 			errs[idx] = rs[idx].Run(ctx, inps[idx], outs[idx])
 			close(outs[idx])
-			// in case of error - drain inps[idx] to allow project keep
-			// duplicating data
 			if errs[idx] != nil {
 				cancel()
 			}
 			wg.Done()
+			// in case of error - drain inps[idx] to allow project keep
+			// duplicating data
 			drain(inps[idx])
 		}(i)
 	}
@@ -115,10 +115,8 @@ func (rs project) Run(origCtx context.Context, inp, out chan Dataset) (err error
 
 		for {
 			select {
-			case <-origCtx.Done():
+			case <-ctx.Done(): // listen to both ctx and origCtx
 				cancel()
-				return
-			case <-ctx.Done():
 				return
 			case data, ok := <-inp:
 				if !ok {

--- a/project.go
+++ b/project.go
@@ -91,15 +91,8 @@ func (rs project) Run(ctx context.Context, inp, out chan Dataset) (err error) {
 		outs[i] = make(chan Dataset)
 		wg.Add(1)
 		go func(idx int) {
-			errs[idx] = rs[idx].Run(ctx, inps[idx], outs[idx])
-			close(outs[idx])
-			if errs[idx] != nil {
-				cancel()
-			}
-			wg.Done()
-			// in case of error - drain inps[idx] to allow project keep
-			// duplicating data
-			drain(inps[idx])
+			defer wg.Done()
+			Run(ctx, rs[idx], inps[idx], outs[idx], cancel, &errs[idx])
 		}(i)
 	}
 

--- a/runner.go
+++ b/runner.go
@@ -90,7 +90,8 @@ type FilterRunner interface {
 	Filter(keep []bool)
 }
 
-// Run rune the given runner and takes care of channels management involved in runner execution
+// Run runs given runner and takes care of channels management involved in runner execution
+// safe to use only if caller created the out channel
 func Run(ctx context.Context, r Runner, inp, out chan Dataset, cancel context.CancelFunc, err *error) {
 	// drain inp in case there are left overs in the channel.
 	// usually this will be a no-op, unless runner has exited early due to an

--- a/runner.go
+++ b/runner.go
@@ -149,3 +149,9 @@ func (r *pick) Run(_ context.Context, inp, out chan Dataset) error {
 	}
 	return nil
 }
+
+// helper function to drain inp/out channel
+func drain(c chan Dataset) {
+	for range c {
+	}
+}

--- a/runner_test.go
+++ b/runner_test.go
@@ -1,0 +1,81 @@
+package ep_test
+
+import (
+	"context"
+	"errors"
+	"github.com/panoplyio/ep"
+	"github.com/stretchr/testify/require"
+	"sync"
+	"testing"
+)
+
+func TestRun_drainInput(t *testing.T) {
+	inp := make(chan ep.Dataset)
+	out := make(chan ep.Dataset)
+	var err error
+
+	// errRunner reads only one batch from its input
+	r := &errRunner{errors.New("err"), "err"}
+
+	go ep.Run(context.Background(), r, inp, out, nil, &err)
+	inp <- ep.NewDatasetTypes([]ep.Type{str}, 10)
+	inp <- ep.NewDatasetTypes([]ep.Type{str}, 10)
+	inp <- ep.NewDatasetTypes([]ep.Type{str}, 10)
+	inp <- ep.NewDatasetTypes([]ep.Type{str}, 10)
+	inp <- ep.NewDatasetTypes([]ep.Type{str}, 10)
+	close(inp)
+
+	for range out {
+	}
+
+	require.Error(t, err)
+	require.Equal(t, "err", err.Error())
+}
+
+func TestRun_closeOut(t *testing.T) {
+	inp := make(chan ep.Dataset)
+	out := make(chan ep.Dataset)
+	var err error
+
+	var wg sync.WaitGroup
+	r := ep.PassThrough()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ep.Run(context.Background(), r, inp, out, nil, &err)
+	}()
+	inp <- ep.NewDatasetTypes([]ep.Type{str}, 10)
+	close(inp)
+
+	result := <-out
+
+	wg.Wait()
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Panics(t, func() { close(out) }, "expected ep.Run to close out channel")
+}
+
+func TestRun_callCancel(t *testing.T) {
+	inp := make(chan ep.Dataset)
+	out := make(chan ep.Dataset)
+	var err error
+	canceledCalled := false
+	cancel := func() {
+		canceledCalled = true
+	}
+
+	r := ep.Pipeline(ep.PassThrough(), &errRunner{errors.New("err"), "err"})
+
+	go ep.Run(context.Background(), r, inp, out, cancel, &err)
+	inp <- ep.NewDatasetTypes([]ep.Type{str}, 10)
+	close(inp)
+
+	for range out {
+	}
+
+	require.Error(t, err)
+	require.Equal(t, "err", err.Error())
+	require.True(t, canceledCalled)
+}

--- a/runner_test.go
+++ b/runner_test.go
@@ -66,7 +66,7 @@ func TestRun_callCancel(t *testing.T) {
 		canceledCalled = true
 	}
 
-	r := ep.Pipeline(ep.PassThrough(), &errRunner{errors.New("err"), "err"})
+	r := &errRunner{errors.New("err"), "err"}
 
 	go ep.Run(context.Background(), r, inp, out, cancel, &err)
 	inp <- ep.NewDatasetTypes([]ep.Type{str}, 10)

--- a/union.go
+++ b/union.go
@@ -94,11 +94,8 @@ func (rs union) Run(ctx context.Context, inp, out chan Dataset) (err error) {
 			close(s)
 		}
 	}()
-	defer func() {
-		// in case of error - drain input
-		for range inp {
-		}
-	}()
+	// in case of error - drain input
+	defer drain(inp)
 
 	// collect and union all of the stream into a single output
 	for _, s := range outputs {

--- a/union.go
+++ b/union.go
@@ -75,10 +75,7 @@ func (rs union) Run(ctx context.Context, inp, out chan Dataset) (err error) {
 		inputs[i] = make(chan Dataset)
 		outputs[i] = make(chan Dataset)
 
-		go func(i int) {
-			defer close(outputs[i])
-			errors[i] = rs[i].Run(ctx, inputs[i], outputs[i])
-		}(i)
+		go Run(ctx, rs[i], inputs[i], outputs[i], nil, &errors[i])
 	}
 
 	// fork the input to all inner runners
@@ -94,8 +91,6 @@ func (rs union) Run(ctx context.Context, inp, out chan Dataset) (err error) {
 			close(s)
 		}
 	}()
-	// in case of error - drain input
-	defer drain(inp)
 
 	// collect and union all of the stream into a single output
 	for _, s := range outputs {


### PR DESCRIPTION
[Task](https://app.asana.com/0/573768021211412/773980942769093)

wrap pipeline `inp` channel with cancel listening, to make sure all consecutive runners will be closed (either if they listen to ctx.done or only to inp).

only pipeline and project are covered at this point.
exchange will be handled in separate PR.

========
**EDIT**: this PR also introduces changes in current approach regarding executors responsibilities.
each place that **both** a) creates channels and b) executes runner should:
1. close out channel at the end (same as today)
2. drain inp channel to allow preceding runner to continue without stuck and be canceled

for that purpose, new function named `ep.Run` was added. `ep.Run` takes care of 1 & 2.
every place that creates channels and executes runner, should use this new function.