### PR TITLE
Prevent unnecessary slices in Batch

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -33,7 +33,10 @@ func (b *batch) Run(ctx context.Context, inp, out chan Dataset) error {
 			if sliceEnd > dataLen {
 				sliceEnd = dataLen
 			}
-			delta := data.Slice(sliceStart, sliceEnd).(Dataset)
+			delta := data
+			if dataLen > rowsLeft || sliceStart > 0 {
+				delta = data.Slice(sliceStart, sliceEnd).(Dataset)
+			}
 
 			if delta.Len() == b.Size {
 				out <- delta


### PR DESCRIPTION
This PR handles a special case where small batches should not be sliced, when they fit into a buffer entirely.