### PR TITLE
Add ApproxSizer interface

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -112,7 +112,7 @@ func (s *scope) ApproxSize() int {
 	if sizer, ok := s.Runner.(ApproxSizer); ok {
 		return sizer.ApproxSize()
 	}
-	return SizeUnknown
+	return UnknownSize
 }
 
 // SetScope sets a scope for the given columns

--- a/alias.go
+++ b/alias.go
@@ -108,6 +108,13 @@ func (s *scope) Push(toPush ScopesRunner) bool {
 	return false
 }
 
+func (s *scope) ApproxSize() int {
+	if sizer, ok := s.Runner.(ApproxSizer); ok {
+		return sizer.ApproxSize()
+	}
+	return 0
+}
+
 // SetScope sets a scope for the given columns
 func SetScope(cols []Type, scope string) []Type {
 	if scope == "" {

--- a/alias.go
+++ b/alias.go
@@ -112,7 +112,7 @@ func (s *scope) ApproxSize() int {
 	if sizer, ok := s.Runner.(ApproxSizer); ok {
 		return sizer.ApproxSize()
 	}
-	return 0
+	return SizeUnknown
 }
 
 // SetScope sets a scope for the given columns

--- a/pipeline.go
+++ b/pipeline.go
@@ -191,3 +191,12 @@ func (rs pipeline) Push(toPush ScopesRunner) bool {
 	}
 	return false
 }
+
+func (rs pipeline) ApproxSize() int {
+	lastIdx := len(rs) - 1
+	last := rs[lastIdx]
+	if approxSizer, ok := last.(ApproxSizer); ok {
+		return approxSizer.ApproxSize()
+	}
+	return SizeUnknown
+}

--- a/pipeline.go
+++ b/pipeline.go
@@ -198,5 +198,5 @@ func (rs pipeline) ApproxSize() int {
 	if approxSizer, ok := last.(ApproxSizer); ok {
 		return approxSizer.ApproxSize()
 	}
-	return SizeUnknown
+	return UnknownSize
 }

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -114,7 +114,7 @@ func TestPipeline_ApproxSize(t *testing.T) {
 		r := ep.Pipeline(&upper{}, &runnerWithSize{size: 42}, &question{})
 		sizer, ok := r.(ep.ApproxSizer)
 		require.True(t, ok)
-		require.Equal(t, ep.SizeUnknown, sizer.ApproxSize())
+		require.Equal(t, ep.UnknownSize, sizer.ApproxSize())
 	})
 }
 

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -103,10 +103,19 @@ func TestPipeline_Args_noArgs(t *testing.T) {
 }
 
 func TestPipeline_ApproxSize(t *testing.T) {
-	r := ep.Pipeline(&upper{}, &runnerWithSize{size: 42})
-	sizer, ok := r.(ep.ApproxSizer)
-	require.True(t, ok)
-	require.Equal(t, 42, sizer.ApproxSize())
+	t.Run("known size", func(t *testing.T) {
+		r := ep.Pipeline(&upper{}, &runnerWithSize{size: 42})
+		sizer, ok := r.(ep.ApproxSizer)
+		require.True(t, ok)
+		require.Equal(t, 42, sizer.ApproxSize())
+	})
+
+	t.Run("unknown size", func(t *testing.T) {
+		r := ep.Pipeline(&upper{}, &runnerWithSize{size: 42}, &question{})
+		sizer, ok := r.(ep.ApproxSizer)
+		require.True(t, ok)
+		require.Equal(t, ep.SizeUnknown, sizer.ApproxSize())
+	})
 }
 
 type tailCutter struct {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -103,7 +103,7 @@ func TestPipeline_Args_noArgs(t *testing.T) {
 }
 
 func TestPipeline_ApproxSize(t *testing.T) {
-	r := ep.Pipeline(ep.PassThrough(), &runnerWithSize{size: 42})
+	r := ep.Pipeline(&upper{}, &runnerWithSize{size: 42})
 	sizer, ok := r.(ep.ApproxSizer)
 	require.True(t, ok)
 	require.Equal(t, 42, sizer.ApproxSize())

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -102,6 +102,13 @@ func TestPipeline_Args_noArgs(t *testing.T) {
 	require.Equal(t, []ep.Type{ep.Wildcard}, args)
 }
 
+func TestPipeline_ApproxSize(t *testing.T) {
+	r := ep.Pipeline(ep.PassThrough(), &runnerWithSize{size: 42})
+	sizer, ok := r.(ep.ApproxSizer)
+	require.True(t, ok)
+	require.Equal(t, 42, sizer.ApproxSize())
+}
+
 type tailCutter struct {
 	CutFromTail int
 }

--- a/project.go
+++ b/project.go
@@ -192,6 +192,22 @@ func (rs project) Scopes() StringsSet {
 	return scopes
 }
 
+func (rs project) ApproxSize() int {
+	totalSize := 0
+	for _, r := range rs {
+		sizer, ok := r.(ApproxSizer)
+		if !ok {
+			return SizeUnknown
+		}
+		size := sizer.ApproxSize()
+		if size == SizeUnknown {
+			return SizeUnknown
+		}
+		totalSize += size
+	}
+	return totalSize
+}
+
 // useDummySingleton replaces all dummies with pre-defined singleton to allow addresses comparison
 // instead of casting for each batch.
 // required for distribute runner that creates new dummy instances instead of using singleton

--- a/project.go
+++ b/project.go
@@ -197,11 +197,11 @@ func (rs project) ApproxSize() int {
 	for _, r := range rs {
 		sizer, ok := r.(ApproxSizer)
 		if !ok {
-			return SizeUnknown
+			return UnknownSize
 		}
 		size := sizer.ApproxSize()
-		if size == SizeUnknown {
-			return SizeUnknown
+		if size == UnknownSize {
+			return UnknownSize
 		}
 		totalSize += size
 	}

--- a/project_test.go
+++ b/project_test.go
@@ -264,7 +264,7 @@ func TestProject_ApproxSize(t *testing.T) {
 		p := ep.Project(r1, r2)
 		sizer, ok := p.(ep.ApproxSizer)
 		require.True(t, ok)
-		require.Equal(t, ep.SizeUnknown, sizer.ApproxSize())
+		require.Equal(t, ep.UnknownSize, sizer.ApproxSize())
 	})
 
 	t.Run("part is ApproxSizer", func(t *testing.T) {
@@ -274,7 +274,7 @@ func TestProject_ApproxSize(t *testing.T) {
 		p := ep.Project(r1, r2)
 		sizer, ok := p.(ep.ApproxSizer)
 		require.True(t, ok)
-		require.Equal(t, ep.SizeUnknown, sizer.ApproxSize())
+		require.Equal(t, ep.UnknownSize, sizer.ApproxSize())
 	})
 
 	t.Run("all are ApproxSizer", func(t *testing.T) {

--- a/project_test.go
+++ b/project_test.go
@@ -255,3 +255,35 @@ func TestProject_Filter_nestedWithInternalAll(t *testing.T) {
 	require.True(t, q2.called)
 	require.Equal(t, "[(is hello?) (is world?)]", fmt.Sprintf("%+v", data.Strings()))
 }
+
+func TestProject_ApproxSize(t *testing.T) {
+	t.Run("none is ApproxSizer", func(t *testing.T) {
+		r1 := ep.PassThrough()
+		r2 := &question{}
+
+		p := ep.Project(r1, r2)
+		sizer, ok := p.(ep.ApproxSizer)
+		require.True(t, ok)
+		require.Equal(t, ep.SizeUnknown, sizer.ApproxSize())
+	})
+
+	t.Run("part is ApproxSizer", func(t *testing.T) {
+		r1 := ep.PassThrough()
+		r2 := &runnerWithSize{size: 42}
+
+		p := ep.Project(r1, r2)
+		sizer, ok := p.(ep.ApproxSizer)
+		require.True(t, ok)
+		require.Equal(t, ep.SizeUnknown, sizer.ApproxSize())
+	})
+
+	t.Run("all are ApproxSizer", func(t *testing.T) {
+		r1 := &runnerWithSize{size: 42}
+		r2 := &runnerWithSize{size: 11}
+
+		p := ep.Project(r1, r2)
+		sizer, ok := p.(ep.ApproxSizer)
+		require.True(t, ok)
+		require.Equal(t, 42+11, sizer.ApproxSize())
+	})
+}

--- a/project_test.go
+++ b/project_test.go
@@ -87,7 +87,8 @@ func TestProject_errorInPipeline(t *testing.T) {
 	require.False(t, infinityRunner3.IsRunning(), "Infinity 3 go-routine leak")
 }
 
-func _TestProject_errorWithExchange(t *testing.T) {
+func TestProject_errorWithExchange(t *testing.T) {
+	t.Skip()
 	port := ":5551"
 	dist := eptest.NewPeer(t, port)
 

--- a/runner.go
+++ b/runner.go
@@ -6,8 +6,7 @@ import (
 
 var _ = registerGob(&passThrough{}, &pick{})
 
-// UnknownSize is a special value that should be returned by ApproxSizers when
-// they cannot give an estimation.
+// UnknownSize is used when size cannot be estimated
 const UnknownSize = -1
 
 // Runner represents objects that can receive a stream of input datasets,

--- a/runner.go
+++ b/runner.go
@@ -6,9 +6,9 @@ import (
 
 var _ = registerGob(&passThrough{}, &pick{})
 
-// SizeUnknown is a special value that should be returned by ApproxSizers when
+// UnknownSize is a special value that should be returned by ApproxSizers when
 // they cannot give an estimation.
-const SizeUnknown = -1
+const UnknownSize = -1
 
 // Runner represents objects that can receive a stream of input datasets,
 // manipulate them in some way (filter, mapping, reduction, expansion, etc.) and

--- a/runner.go
+++ b/runner.go
@@ -112,6 +112,14 @@ type PushRunner interface {
 	Push(toPush ScopesRunner) bool
 }
 
+// ApproxSizer is a Runner that can roughly predict the size of its output
+type ApproxSizer interface {
+	Runner
+
+	// ApproxSize returns a roughly estimated size of the output produced by this Runner
+	ApproxSize() int
+}
+
 // Run runs given runner and takes care of channels management involved in runner execution
 // safe to use only if caller created the out channel
 func Run(ctx context.Context, r Runner, inp, out chan Dataset, cancel context.CancelFunc, err *error) {

--- a/runner.go
+++ b/runner.go
@@ -6,6 +6,10 @@ import (
 
 var _ = registerGob(&passThrough{}, &pick{})
 
+// SizeUnknown is a special value that should be returned by ApproxSizers when
+// they cannot give an estimation.
+const SizeUnknown = -1
+
 // Runner represents objects that can receive a stream of input datasets,
 // manipulate them in some way (filter, mapping, reduction, expansion, etc.) and
 // and produce a new stream of the formatted values.

--- a/runner_example_test.go
+++ b/runner_example_test.go
@@ -35,3 +35,20 @@ func ExampleScopesRunner_Scopes() {
 	// Output:
 	// map[upper_scope:{}]
 }
+
+func ExampleApproxSizer() {
+	var runner ep.Runner = &runnerWithSize{size: 42}
+	fmt.Println(runner.(ep.ApproxSizer).ApproxSize())
+
+	// Output:
+	// 42
+}
+
+type runnerWithSize struct {
+	ep.Runner
+	size int
+}
+
+func (r *runnerWithSize) ApproxSize() int {
+	return r.size
+}


### PR DESCRIPTION
[Task](https://app.asana.com/0/573768021211412/1107587400397456/f)

Since we sometimes need to estimate the size of Runners' output, some runners should be marked as the ones that can estimate their own size. These runners will be called `ApproxSizer`s.