### PR TITLE
DataBuilder interface

### DIFF
--- a/data.go
+++ b/data.go
@@ -74,7 +74,9 @@ type DataBuilder interface {
 
 	// Data returns a new Data object containing all appended Data objects in
 	// the same order. Subsequent Append() calls on this builder do not affect
-	// the returned Data object.
+	// the returned Data object. Calling Data() on DataBuilder objects without
+	// preceding Append() calls is not allowed, and the behavior in such cases
+	// is undefined
 	Data() Data
 }
 

--- a/data.go
+++ b/data.go
@@ -61,6 +61,24 @@ type Data interface {
 	Strings() []string
 }
 
+// DataBuilder exposes an efficient way to build Data objects by appending
+// smaller Data objects. DataBuilders should be used every time there is a need
+// to Append multiple Datas.
+//
+// The flow is:
+// - create a DataBuilder (very small allocation)
+// - Append() as many Datas as needed (allocate space to hold more pointers to Data)
+// - Finally call Data() to allocate a single Data object containing all
+//   Appended Datas (large, one time allocation)
+type DataBuilder interface {
+	// Append appends data to the data that this DataBuilder has
+	Append(data Data)
+
+	// Data allocates a new Data object and adds every appended Data object to
+	// it, keeping the order
+	Data() Data
+}
+
 // Cut the Data into several sub-segments at the provided cut-point indices. It's
 // effectively the same as calling Data.Slice() multiple times
 func Cut(data Data, cutPoints ...int) []Data {

--- a/data.go
+++ b/data.go
@@ -63,19 +63,18 @@ type Data interface {
 
 // DataBuilder exposes an efficient way to build Data objects by appending
 // smaller Data objects. DataBuilders should be used every time there is a need
-// to Append multiple Datas.
+// to Append multiple Data objects.
 //
-// The flow is:
-// - create a DataBuilder (very small allocation)
-// - Append() as many Datas as needed (allocate space to hold more pointers to Data)
-// - Finally call Data() to allocate a single Data object containing all
-//   Appended Datas (large, one time allocation)
+// Append() method can be called multiple times without significant
+// allocations. Calling Data() will return a new Data object containing all
+// appended Data objects.
 type DataBuilder interface {
 	// Append appends data to the data that this DataBuilder has
 	Append(data Data)
 
-	// Data allocates a new Data object and adds every appended Data object to
-	// it, keeping the order
+	// Data returns a new Data object containing all appended Data objects in
+	// the same order. Subsequent Append() calls on this builder do not affect
+	// the returned Data object.
 	Data() Data
 }
 

--- a/data_builder_test.go
+++ b/data_builder_test.go
@@ -8,14 +8,14 @@ import (
 
 func TestDataBuilder(t *testing.T) {
 	t.Run("one data", func(t *testing.T) {
-		db := integer.DataBuilder()
+		db := integer.Builder()
 		db.Append(integer.Data(10))
 		data := db.Data()
 		require.Equal(t, 10, data.Len())
 	})
 
 	t.Run("many datas", func(t *testing.T) {
-		db := integer.DataBuilder()
+		db := integer.Builder()
 		db.Append(integer.Data(7))
 		db.Append(integer.Data(11))
 		db.Append(integer.Data(13))
@@ -106,7 +106,7 @@ func BenchmarkDataBuilder(b *testing.B) {
 	b.Run("integer", func(b *testing.B) {
 		b.Run("DataBuilder", func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				db := integer.DataBuilder()
+				db := integer.Builder()
 				for j := 0; j < len(dataInts); j++ {
 					db.Append(dataInts[j])
 				}
@@ -129,7 +129,7 @@ func BenchmarkDataBuilder(b *testing.B) {
 	b.Run("string", func(b *testing.B) {
 		b.Run("DataBuilder", func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				db := str.DataBuilder()
+				db := str.Builder()
 				for j := 0; j < len(dataStrs); j++ {
 					db.Append(dataStrs[j])
 				}

--- a/data_builder_test.go
+++ b/data_builder_test.go
@@ -14,7 +14,7 @@ func TestDataBuilder(t *testing.T) {
 		require.Equal(t, 10, data.Len())
 	})
 
-	t.Run("many datas", func(t *testing.T) {
+	t.Run("multiple Data objects", func(t *testing.T) {
 		db := integer.Builder()
 		db.Append(integer.Data(7))
 		db.Append(integer.Data(11))

--- a/data_builder_test.go
+++ b/data_builder_test.go
@@ -64,6 +64,33 @@ func TestDataBuilder(t *testing.T) {
 		require.Equal(t, 67, dataset.Len())
 		require.Equal(t, 2, dataset.Width())
 	})
+
+	t.Run("records", func(t *testing.T) {
+		db := ep.NewDatasetBuilder()
+		d1 := integer.Data(7)
+		d2 := integer.Data(11)
+		d3 := integer.Data(13)
+		d4 := integer.Data(17)
+		d5 := integer.Data(19)
+
+		ds1 := ep.NewDataset(ep.NewDataset(d1), ep.NewDataset(d1))
+		ds2 := ep.NewDataset(ep.NewDataset(d2), ep.NewDataset(d2))
+		ds3 := ep.NewDataset(ep.NewDataset(d3), ep.NewDataset(d3))
+		ds4 := ep.NewDataset(ep.NewDataset(d4), ep.NewDataset(d4))
+		ds5 := ep.NewDataset(ep.NewDataset(d5), ep.NewDataset(d5))
+
+		db.Append(ds1)
+		db.Append(ds2)
+		db.Append(ds3)
+		db.Append(ds4)
+		db.Append(ds5)
+		data := db.Data()
+
+		dataset, ok := data.(ep.Dataset)
+		require.True(t, ok)
+		require.Equal(t, 67, dataset.Len())
+		require.Equal(t, 2, dataset.Width())
+	})
 }
 
 func BenchmarkDataBuilder(b *testing.B) {

--- a/data_builder_test.go
+++ b/data_builder_test.go
@@ -1,0 +1,147 @@
+package ep_test
+
+import (
+	"github.com/panoplyio/ep"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestDataBuilder(t *testing.T) {
+	t.Run("one data", func(t *testing.T) {
+		db := integer.DataBuilder()
+		db.Append(integer.Data(10))
+		data := db.Data()
+		require.Equal(t, 10, data.Len())
+	})
+
+	t.Run("many datas", func(t *testing.T) {
+		db := integer.DataBuilder()
+		db.Append(integer.Data(7))
+		db.Append(integer.Data(11))
+		db.Append(integer.Data(13))
+		db.Append(integer.Data(17))
+		db.Append(integer.Data(19))
+		data := db.Data()
+		require.Equal(t, 67, data.Len())
+	})
+
+	t.Run("one dataset", func(t *testing.T) {
+		db := ep.NewDatasetBuilder()
+		d := integer.Data(10)
+		ds := ep.NewDataset(d, d)
+		db.Append(ds)
+		data := db.Data()
+
+		dataset, ok := data.(ep.Dataset)
+		require.True(t, ok)
+		require.Equal(t, 10, dataset.Len())
+		require.Equal(t, 2, dataset.Width())
+	})
+
+	t.Run("many datasets", func(t *testing.T) {
+		db := ep.NewDatasetBuilder()
+		d1 := integer.Data(7)
+		d2 := integer.Data(11)
+		d3 := integer.Data(13)
+		d4 := integer.Data(17)
+		d5 := integer.Data(19)
+
+		ds1 := ep.NewDataset(d1, d1)
+		ds2 := ep.NewDataset(d2, d2)
+		ds3 := ep.NewDataset(d3, d3)
+		ds4 := ep.NewDataset(d4, d4)
+		ds5 := ep.NewDataset(d5, d5)
+
+		db.Append(ds1)
+		db.Append(ds2)
+		db.Append(ds3)
+		db.Append(ds4)
+		db.Append(ds5)
+		data := db.Data()
+
+		dataset, ok := data.(ep.Dataset)
+		require.True(t, ok)
+		require.Equal(t, 67, dataset.Len())
+		require.Equal(t, 2, dataset.Width())
+	})
+}
+
+func BenchmarkDataBuilder(b *testing.B) {
+	dataInts := make([]ep.Data, 100)
+	dataStrs := make([]ep.Data, 100)
+	dataBoth := make([]ep.Dataset, 100)
+	for i := 0; i < len(dataInts); i++ {
+		dataInts[i] = integer.Data(1000)
+		dataStrs[i] = str.Data(1000)
+		dataBoth[i] = ep.NewDataset(dataInts[i], dataStrs[i])
+	}
+
+	b.Run("integer", func(b *testing.B) {
+		b.Run("DataBuilder", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				db := integer.DataBuilder()
+				for j := 0; j < len(dataInts); j++ {
+					db.Append(dataInts[j])
+				}
+				data := db.Data()
+				require.Equal(b, 100*1000, data.Len())
+			}
+		})
+
+		b.Run("Append", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				data := dataInts[0].Type().Data(0)
+				for j := 0; j < len(dataInts); j++ {
+					data = data.Append(dataInts[j])
+				}
+				require.Equal(b, 100*1000, data.Len())
+			}
+		})
+	})
+
+	b.Run("string", func(b *testing.B) {
+		b.Run("DataBuilder", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				db := str.DataBuilder()
+				for j := 0; j < len(dataStrs); j++ {
+					db.Append(dataStrs[j])
+				}
+				data := db.Data()
+				require.Equal(b, 100*1000, data.Len())
+			}
+		})
+
+		b.Run("Append", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				data := dataStrs[0].Type().Data(0)
+				for j := 0; j < len(dataStrs); j++ {
+					data = data.Append(dataStrs[j])
+				}
+				require.Equal(b, 100*1000, data.Len())
+			}
+		})
+	})
+
+	b.Run("both", func(b *testing.B) {
+		b.Run("DataBuilder", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				db := ep.NewDatasetBuilder()
+				for j := 0; j < len(dataBoth); j++ {
+					db.Append(dataBoth[j])
+				}
+				data := db.Data()
+				require.Equal(b, 100*1000, data.Len())
+			}
+		})
+
+		b.Run("Append", func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				var data ep.Data = ep.NewDataset()
+				for j := 0; j < len(dataBoth); j++ {
+					data = data.Append(dataBoth[j])
+				}
+				require.Equal(b, 100*1000, data.Len())
+			}
+		})
+	})
+}

--- a/data_builder_test.go
+++ b/data_builder_test.go
@@ -1,96 +1,29 @@
 package ep_test
 
 import (
+	"fmt"
 	"github.com/panoplyio/ep"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
-func TestDataBuilder(t *testing.T) {
-	t.Run("one data", func(t *testing.T) {
-		db := integer.Builder()
-		db.Append(integer.Data(10))
-		data := db.Data()
-		require.Equal(t, 10, data.Len())
-	})
+func ExampleDataBuilder() {
+	data1 := ep.NewDataset(
+		integers{1, 2, 3},
+		strs{"a", "b", "c"},
+	)
+	data2 := ep.NewDataset(
+		integers{4, 5, 6, 7},
+		strs{"d", "e", "f", "g"},
+	)
 
-	t.Run("multiple Data objects", func(t *testing.T) {
-		db := integer.Builder()
-		db.Append(integer.Data(7))
-		db.Append(integer.Data(11))
-		db.Append(integer.Data(13))
-		db.Append(integer.Data(17))
-		db.Append(integer.Data(19))
-		data := db.Data()
-		require.Equal(t, 67, data.Len())
-	})
+	builder := ep.NewDatasetBuilder()
+	builder.Append(data1)
+	builder.Append(data2)
+	fmt.Println(builder.Data().Strings())
 
-	t.Run("one dataset", func(t *testing.T) {
-		db := ep.NewDatasetBuilder()
-		d := integer.Data(10)
-		ds := ep.NewDataset(d, d)
-		db.Append(ds)
-		data := db.Data()
-
-		dataset, ok := data.(ep.Dataset)
-		require.True(t, ok)
-		require.Equal(t, 10, dataset.Len())
-		require.Equal(t, 2, dataset.Width())
-	})
-
-	t.Run("many datasets", func(t *testing.T) {
-		db := ep.NewDatasetBuilder()
-		d1 := integer.Data(7)
-		d2 := integer.Data(11)
-		d3 := integer.Data(13)
-		d4 := integer.Data(17)
-		d5 := integer.Data(19)
-
-		ds1 := ep.NewDataset(d1, d1)
-		ds2 := ep.NewDataset(d2, d2)
-		ds3 := ep.NewDataset(d3, d3)
-		ds4 := ep.NewDataset(d4, d4)
-		ds5 := ep.NewDataset(d5, d5)
-
-		db.Append(ds1)
-		db.Append(ds2)
-		db.Append(ds3)
-		db.Append(ds4)
-		db.Append(ds5)
-		data := db.Data()
-
-		dataset, ok := data.(ep.Dataset)
-		require.True(t, ok)
-		require.Equal(t, 67, dataset.Len())
-		require.Equal(t, 2, dataset.Width())
-	})
-
-	t.Run("records", func(t *testing.T) {
-		db := ep.NewDatasetBuilder()
-		d1 := integer.Data(7)
-		d2 := integer.Data(11)
-		d3 := integer.Data(13)
-		d4 := integer.Data(17)
-		d5 := integer.Data(19)
-
-		ds1 := ep.NewDataset(ep.NewDataset(d1), ep.NewDataset(d1))
-		ds2 := ep.NewDataset(ep.NewDataset(d2), ep.NewDataset(d2))
-		ds3 := ep.NewDataset(ep.NewDataset(d3), ep.NewDataset(d3))
-		ds4 := ep.NewDataset(ep.NewDataset(d4), ep.NewDataset(d4))
-		ds5 := ep.NewDataset(ep.NewDataset(d5), ep.NewDataset(d5))
-
-		db.Append(ds1)
-		db.Append(ds2)
-		db.Append(ds3)
-		db.Append(ds4)
-		db.Append(ds5)
-		data := db.Data()
-
-		dataset, ok := data.(ep.Dataset)
-		require.True(t, ok)
-		require.Equal(t, 67, dataset.Len())
-		require.Equal(t, 2, dataset.Width())
-	})
+	// Output:
+	// [(1,a) (2,b) (3,c) (4,d) (5,e) (6,f) (7,g)]
 }
 
 func BenchmarkDataBuilder(b *testing.B) {

--- a/data_example_test.go
+++ b/data_example_test.go
@@ -22,6 +22,28 @@ func (*strType) Name() string            { return "string" }
 func (*strType) Size() uint              { return 8 }
 func (*strType) Data(n int) ep.Data      { return make(strs, n) }
 func (*strType) DataEmpty(n int) ep.Data { return make(strs, 0, n) }
+func (*strType) DataBuilder() ep.DataBuilder {
+	return &strBuilder{}
+}
+
+type strBuilder struct {
+	Ds  []strs
+	Len int
+}
+
+func (s *strBuilder) Append(data ep.Data) {
+	strData := data.(strs)
+	s.Ds = append(s.Ds, strData)
+	s.Len += strData.Len()
+}
+
+func (s *strBuilder) Data() ep.Data {
+	res := make(strs, 0, s.Len)
+	for _, d := range s.Ds {
+		res = append(res, d...)
+	}
+	return res
+}
 
 type strs []string
 
@@ -83,6 +105,28 @@ func (*integerType) Name() string            { return "integer" }
 func (*integerType) Size() uint              { return 4 }
 func (*integerType) Data(n int) ep.Data      { return make(integers, n) }
 func (*integerType) DataEmpty(n int) ep.Data { return make(integers, 0, n) }
+func (*integerType) DataBuilder() ep.DataBuilder {
+	return &integerBuilder{}
+}
+
+type integerBuilder struct {
+	Ds  []integers
+	Len int
+}
+
+func (s *integerBuilder) Append(data ep.Data) {
+	intData := data.(integers)
+	s.Ds = append(s.Ds, intData)
+	s.Len += intData.Len()
+}
+
+func (s *integerBuilder) Data() ep.Data {
+	res := make(integers, 0, s.Len)
+	for _, d := range s.Ds {
+		res = append(res, d...)
+	}
+	return res
+}
 
 type integers []int
 

--- a/data_example_test.go
+++ b/data_example_test.go
@@ -22,7 +22,7 @@ func (*strType) Name() string            { return "string" }
 func (*strType) Size() uint              { return 8 }
 func (*strType) Data(n int) ep.Data      { return make(strs, n) }
 func (*strType) DataEmpty(n int) ep.Data { return make(strs, 0, n) }
-func (*strType) DataBuilder() ep.DataBuilder {
+func (*strType) Builder() ep.DataBuilder {
 	return &strBuilder{}
 }
 
@@ -105,7 +105,7 @@ func (*integerType) Name() string            { return "integer" }
 func (*integerType) Size() uint              { return 4 }
 func (*integerType) Data(n int) ep.Data      { return make(integers, n) }
 func (*integerType) DataEmpty(n int) ep.Data { return make(integers, 0, n) }
-func (*integerType) DataBuilder() ep.DataBuilder {
+func (*integerType) Builder() ep.DataBuilder {
 	return &integerBuilder{}
 }
 

--- a/data_example_test.go
+++ b/data_example_test.go
@@ -27,19 +27,19 @@ func (*strType) Builder() ep.DataBuilder {
 }
 
 type strBuilder struct {
-	Ds  []strs
-	Len int
+	ds  []strs
+	len int
 }
 
 func (s *strBuilder) Append(data ep.Data) {
 	strData := data.(strs)
-	s.Ds = append(s.Ds, strData)
-	s.Len += strData.Len()
+	s.ds = append(s.ds, strData)
+	s.len += strData.Len()
 }
 
 func (s *strBuilder) Data() ep.Data {
-	res := make(strs, 0, s.Len)
-	for _, d := range s.Ds {
+	res := make(strs, 0, s.len)
+	for _, d := range s.ds {
 		res = append(res, d...)
 	}
 	return res
@@ -110,19 +110,19 @@ func (*integerType) Builder() ep.DataBuilder {
 }
 
 type integerBuilder struct {
-	Ds  []integers
-	Len int
+	ds  []integers
+	len int
 }
 
 func (s *integerBuilder) Append(data ep.Data) {
 	intData := data.(integers)
-	s.Ds = append(s.Ds, intData)
-	s.Len += intData.Len()
+	s.ds = append(s.ds, intData)
+	s.len += intData.Len()
 }
 
 func (s *integerBuilder) Data() ep.Data {
-	res := make(integers, 0, s.Len)
-	for _, d := range s.Ds {
+	res := make(integers, 0, s.len)
+	for _, d := range s.ds {
 		res = append(res, d...)
 	}
 	return res

--- a/data_example_test.go
+++ b/data_example_test.go
@@ -31,15 +31,15 @@ type strBuilder struct {
 	len int
 }
 
-func (s *strBuilder) Append(data ep.Data) {
+func (sb *strBuilder) Append(data ep.Data) {
 	strData := data.(strs)
-	s.ds = append(s.ds, strData)
-	s.len += strData.Len()
+	sb.ds = append(sb.ds, strData)
+	sb.len += strData.Len()
 }
 
-func (s *strBuilder) Data() ep.Data {
-	res := make(strs, 0, s.len)
-	for _, d := range s.ds {
+func (sb *strBuilder) Data() ep.Data {
+	res := make(strs, 0, sb.len)
+	for _, d := range sb.ds {
 		res = append(res, d...)
 	}
 	return res
@@ -114,15 +114,15 @@ type integerBuilder struct {
 	len int
 }
 
-func (s *integerBuilder) Append(data ep.Data) {
+func (ib *integerBuilder) Append(data ep.Data) {
 	intData := data.(integers)
-	s.ds = append(s.ds, intData)
-	s.len += intData.Len()
+	ib.ds = append(ib.ds, intData)
+	ib.len += intData.Len()
 }
 
-func (s *integerBuilder) Data() ep.Data {
-	res := make(integers, 0, s.len)
-	for _, d := range s.ds {
+func (ib *integerBuilder) Data() ep.Data {
+	res := make(integers, 0, ib.len)
+	for _, d := range ib.ds {
 		res = append(res, d...)
 	}
 	return res

--- a/data_example_test.go
+++ b/data_example_test.go
@@ -31,15 +31,15 @@ type strBuilder struct {
 	len int
 }
 
-func (sb *strBuilder) Append(data ep.Data) {
+func (b *strBuilder) Append(data ep.Data) {
 	strData := data.(strs)
-	sb.ds = append(sb.ds, strData)
-	sb.len += strData.Len()
+	b.ds = append(b.ds, strData)
+	b.len += strData.Len()
 }
 
-func (sb *strBuilder) Data() ep.Data {
-	res := make(strs, 0, sb.len)
-	for _, d := range sb.ds {
+func (b *strBuilder) Data() ep.Data {
+	res := make(strs, 0, b.len)
+	for _, d := range b.ds {
 		res = append(res, d...)
 	}
 	return res
@@ -114,15 +114,15 @@ type integerBuilder struct {
 	len int
 }
 
-func (ib *integerBuilder) Append(data ep.Data) {
+func (b *integerBuilder) Append(data ep.Data) {
 	intData := data.(integers)
-	ib.ds = append(ib.ds, intData)
-	ib.len += intData.Len()
+	b.ds = append(b.ds, intData)
+	b.len += intData.Len()
 }
 
-func (ib *integerBuilder) Data() ep.Data {
-	res := make(integers, 0, ib.len)
-	for _, d := range ib.ds {
+func (b *integerBuilder) Data() ep.Data {
+	res := make(integers, 0, b.len)
+	for _, d := range b.ds {
 		res = append(res, d...)
 	}
 	return res

--- a/dataset.go
+++ b/dataset.go
@@ -107,7 +107,12 @@ func (db *datasetBuilder) Data() Data {
 	cols := make([]Data, firstData.Width())
 	builders := make([]DataBuilder, len(cols))
 	for i := range cols {
-		builders[i] = firstData.At(i).Type().DataBuilder()
+		typee := firstData.At(i).Type()
+		if typee.Name() == Record.Name() {
+			builders[i] = NewDatasetBuilder()
+		} else {
+			builders[i] = typee.DataBuilder()
+		}
 	}
 	for _, d := range db.ds {
 		for i := 0; i < d.Width(); i++ {

--- a/dataset.go
+++ b/dataset.go
@@ -92,16 +92,16 @@ func NewDatasetBuilder() DataBuilder {
 }
 
 type datasetBuilder struct {
-	ds []Dataset
+	sets []Dataset
 }
 
 func (db *datasetBuilder) Append(data Data) {
-	db.ds = append(db.ds, data.(Dataset))
+	db.sets = append(db.sets, data.(Dataset))
 }
 
 func (db *datasetBuilder) Data() Data {
-	firstData := db.ds[0]
-	if len(db.ds) == 1 {
+	firstData := db.sets[0]
+	if len(db.sets) == 1 {
 		return firstData
 	}
 	cols := make([]Data, firstData.Width())
@@ -110,7 +110,7 @@ func (db *datasetBuilder) Data() Data {
 		typee := firstData.At(i).Type()
 		builders[i] = typee.Builder()
 	}
-	for _, d := range db.ds {
+	for _, d := range db.sets {
 		for i := 0; i < d.Width(); i++ {
 			builders[i].Append(d.At(i))
 		}

--- a/dataset.go
+++ b/dataset.go
@@ -92,27 +92,27 @@ func NewDatasetBuilder() DataBuilder {
 }
 
 type datasetBuilder struct {
-	builders []DataBuilder
+	cols []DataBuilder
 }
 
-func (db *datasetBuilder) Append(data Data) {
+func (b *datasetBuilder) Append(data Data) {
 	ds := data.(Dataset)
-	if len(db.builders) == 0 {
-		db.builders = make([]DataBuilder, ds.Width())
-		for i := range db.builders {
+	if len(b.cols) == 0 {
+		b.cols = make([]DataBuilder, ds.Width())
+		for i := range b.cols {
 			typee := ds.At(i).Type()
-			db.builders[i] = typee.Builder()
+			b.cols[i] = typee.Builder()
 		}
 	}
 
-	for i, b := range db.builders {
+	for i, b := range b.cols {
 		b.Append(ds.At(i))
 	}
 }
 
-func (db *datasetBuilder) Data() Data {
-	cols := make([]Data, len(db.builders))
-	for i, b := range db.builders {
+func (b *datasetBuilder) Data() Data {
+	cols := make([]Data, len(b.cols))
+	for i, b := range b.cols {
 		cols[i] = b.Data()
 	}
 	return NewDataset(cols...)

--- a/dataset.go
+++ b/dataset.go
@@ -45,7 +45,7 @@ func (*datasetType) Name() string         { return "record" }
 func (*datasetType) Size() uint           { panic("call Size on each Data") }
 func (sett *datasetType) Data(n int) Data { return sett.DataEmpty(n) }
 func (*datasetType) DataEmpty(int) Data   { panic("use NewDataset function") }
-func (*datasetType) Builder() DataBuilder { panic("use NewDatasetBuilder function") }
+func (*datasetType) Builder() DataBuilder { return NewDatasetBuilder() }
 
 type dataset []Data
 
@@ -108,11 +108,7 @@ func (db *datasetBuilder) Data() Data {
 	builders := make([]DataBuilder, len(cols))
 	for i := range cols {
 		typee := firstData.At(i).Type()
-		if typee.Name() == Record.Name() {
-			builders[i] = NewDatasetBuilder()
-		} else {
-			builders[i] = typee.Builder()
-		}
+		builders[i] = typee.Builder()
 	}
 	for _, d := range db.ds {
 		for i := 0; i < d.Width(); i++ {

--- a/dataset.go
+++ b/dataset.go
@@ -105,8 +105,8 @@ func (db *datasetBuilder) Append(data Data) {
 		}
 	}
 
-	for i := range db.builders {
-		db.builders[i].Append(ds.At(i))
+	for i, b := range db.builders {
+		b.Append(ds.At(i))
 	}
 }
 

--- a/dataset.go
+++ b/dataset.go
@@ -273,7 +273,7 @@ func (set dataset) Duplicate(t int) Data {
 
 // see Data.IsNull
 func (set dataset) IsNull(i int) bool {
-	// i-th row considered to be null iff it contains only nulls
+	// i-th row considered to be null if it contains only nulls
 	for _, d := range set {
 		if !d.IsNull(i) {
 			return false

--- a/dataset.go
+++ b/dataset.go
@@ -40,12 +40,12 @@ var Record = &datasetType{}
 
 type datasetType struct{}
 
-func (sett *datasetType) String() string      { return sett.Name() }
-func (*datasetType) Name() string             { return "record" }
-func (*datasetType) Size() uint               { panic("call Size on each Data") }
-func (sett *datasetType) Data(n int) Data     { return sett.DataEmpty(n) }
-func (*datasetType) DataEmpty(int) Data       { panic("use NewDataset function") }
-func (*datasetType) DataBuilder() DataBuilder { panic("use NewDatasetBuilder function") }
+func (sett *datasetType) String() string  { return sett.Name() }
+func (*datasetType) Name() string         { return "record" }
+func (*datasetType) Size() uint           { panic("call Size on each Data") }
+func (sett *datasetType) Data(n int) Data { return sett.DataEmpty(n) }
+func (*datasetType) DataEmpty(int) Data   { panic("use NewDataset function") }
+func (*datasetType) Builder() DataBuilder { panic("use NewDatasetBuilder function") }
 
 type dataset []Data
 
@@ -111,7 +111,7 @@ func (db *datasetBuilder) Data() Data {
 		if typee.Name() == Record.Name() {
 			builders[i] = NewDatasetBuilder()
 		} else {
-			builders[i] = typee.DataBuilder()
+			builders[i] = typee.Builder()
 		}
 	}
 	for _, d := range db.ds {

--- a/dataset.go
+++ b/dataset.go
@@ -40,11 +40,12 @@ var Record = &datasetType{}
 
 type datasetType struct{}
 
-func (sett *datasetType) String() string  { return sett.Name() }
-func (*datasetType) Name() string         { return "record" }
-func (*datasetType) Size() uint           { panic("call Size on each Data") }
-func (sett *datasetType) Data(n int) Data { return sett.DataEmpty(n) }
-func (*datasetType) DataEmpty(int) Data   { panic("use NewDataset function") }
+func (sett *datasetType) String() string      { return sett.Name() }
+func (*datasetType) Name() string             { return "record" }
+func (*datasetType) Size() uint               { panic("call Size on each Data") }
+func (sett *datasetType) Data(n int) Data     { return sett.DataEmpty(n) }
+func (*datasetType) DataEmpty(int) Data       { panic("use NewDataset function") }
+func (*datasetType) DataBuilder() DataBuilder { panic("use NewDatasetBuilder function") }
 
 type dataset []Data
 

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -184,18 +184,3 @@ func TestDataset_Compare_mixTypes(t *testing.T) {
 	results, _ = d1Dataset.Compare(d2Dataset)
 	require.Equal(t, expected, results)
 }
-
-func TestDataset_Builder(t *testing.T) {
-	ds1 := ep.NewDataset(
-		integers{1, 2, 3},
-		strs{"a", "b", "c"},
-	)
-	ds2 := ep.NewDataset(
-		integers{4, 5},
-		strs{"d", "e"},
-	)
-
-	ds1.MarkNull(1)
-	ds2.MarkNull(0)
-	eptest.VerifyDataBuilder(t, ds1, ds2)
-}

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -184,3 +184,18 @@ func TestDataset_Compare_mixTypes(t *testing.T) {
 	results, _ = d1Dataset.Compare(d2Dataset)
 	require.Equal(t, expected, results)
 }
+
+func TestDataset_DataBuilder(t *testing.T) {
+	ds1 := ep.NewDataset(
+		integers{1, 2, 3},
+		strs{"a", "b", "c"},
+	)
+	ds2 := ep.NewDataset(
+		integers{4, 5},
+		strs{"d", "e"},
+	)
+
+	ds1.MarkNull(1)
+	ds2.MarkNull(0)
+	eptest.VerifyDataBuilder(t, ds1, ds2)
+}

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -185,7 +185,7 @@ func TestDataset_Compare_mixTypes(t *testing.T) {
 	require.Equal(t, expected, results)
 }
 
-func TestDataset_DataBuilder(t *testing.T) {
+func TestDataset_Builder(t *testing.T) {
 	ds1 := ep.NewDataset(
 		integers{1, 2, 3},
 		strs{"a", "b", "c"},

--- a/dummy.go
+++ b/dummy.go
@@ -8,11 +8,12 @@ var _ = registerGob(dummy, dummyData)
 
 type dummyType struct{}
 
-func (t *dummyType) String() string   { return t.Name() }
-func (*dummyType) Name() string       { return "dummy" }
-func (*dummyType) Size() uint         { return 0 }
-func (*dummyType) Data(int) Data      { return dummyData }
-func (*dummyType) DataEmpty(int) Data { return dummyData }
+func (t *dummyType) String() string         { return t.Name() }
+func (*dummyType) Name() string             { return "dummy" }
+func (*dummyType) Size() uint               { return 0 }
+func (*dummyType) Data(int) Data            { return dummyData }
+func (*dummyType) DataEmpty(int) Data       { return dummyData }
+func (*dummyType) DataBuilder() DataBuilder { return nil }
 
 type variadicDummies struct{}
 

--- a/dummy.go
+++ b/dummy.go
@@ -9,12 +9,12 @@ var _ = registerGob(dummy, dummyData)
 
 type dummyType struct{}
 
-func (t *dummyType) String() string         { return t.Name() }
-func (*dummyType) Name() string             { return "dummy" }
-func (*dummyType) Size() uint               { return 0 }
-func (*dummyType) Data(int) Data            { return dummyData }
-func (*dummyType) DataEmpty(int) Data       { return dummyData }
-func (*dummyType) DataBuilder() DataBuilder { return dummyBuilder }
+func (t *dummyType) String() string     { return t.Name() }
+func (*dummyType) Name() string         { return "dummy" }
+func (*dummyType) Size() uint           { return 0 }
+func (*dummyType) Data(int) Data        { return dummyData }
+func (*dummyType) DataEmpty(int) Data   { return dummyData }
+func (*dummyType) Builder() DataBuilder { return dummyBuilder }
 
 type dummyDataBuilder struct{}
 

--- a/dummy.go
+++ b/dummy.go
@@ -4,6 +4,7 @@ import "github.com/panoplyio/ep/compare"
 
 var dummy = &dummyType{}
 var dummyData = &variadicDummies{}
+var dummyBuilder = &dummyDataBuilder{}
 var _ = registerGob(dummy, dummyData)
 
 type dummyType struct{}
@@ -13,7 +14,12 @@ func (*dummyType) Name() string             { return "dummy" }
 func (*dummyType) Size() uint               { return 0 }
 func (*dummyType) Data(int) Data            { return dummyData }
 func (*dummyType) DataEmpty(int) Data       { return dummyData }
-func (*dummyType) DataBuilder() DataBuilder { return nil }
+func (*dummyType) DataBuilder() DataBuilder { return dummyBuilder }
+
+type dummyDataBuilder struct{}
+
+func (*dummyDataBuilder) Append(data Data) {}
+func (*dummyDataBuilder) Data() Data       { return dummyData }
 
 type variadicDummies struct{}
 

--- a/eptest/data.go
+++ b/eptest/data.go
@@ -199,27 +199,20 @@ func VerifyDataNullsHandling(t *testing.T, data ep.Data, expectedNullString stri
 }
 
 // VerifyDataBuilder makes sure DataBuilder works on a given type
-func VerifyDataBuilder(t *testing.T, datas ...ep.Data) {
-	typee := datas[0].Type()
+func VerifyDataBuilder(t *testing.T, data ep.Data) {
+	typee := data.Type()
+	builder := typee.Builder()
+	data.MarkNull(0)
 
-	t.Run("TestDataBuilder_"+typee.String(), func(t *testing.T) {
-		builder := typee.Builder()
+	builder.Append(data)
+	res := builder.Data()
+	require.Equal(t, data.Strings(), res.Strings())
+	require.True(t, res.IsNull(0), "first row should be null")
 
-		for _, d := range datas {
-			builder.Append(d)
-		}
-
-		res := builder.Data()
-
-		var expected ep.Data
-		for _, d := range datas {
-			if expected == nil {
-				expected = d
-			} else {
-				expected = expected.Append(d)
-			}
-		}
-
-		require.Equal(t, expected.Strings(), res.Strings())
-	})
+	builder.Append(data)
+	res = builder.Data()
+	require.Equal(t, data.Len()*2, res.Len())
+	require.True(t, res.IsNull(0))
+	require.True(t, res.IsNull(data.Len()))
+	require.Equal(t, append(data.Strings(), data.Strings()...), res.Strings())
 }

--- a/eptest/data.go
+++ b/eptest/data.go
@@ -197,3 +197,29 @@ func VerifyDataNullsHandling(t *testing.T, data ep.Data, expectedNullString stri
 		require.Equal(t, expectedNullString, strings[nullIdx])
 	})
 }
+
+// VerifyDataBuilder makes sure DataBuilder works on a given type
+func VerifyDataBuilder(t *testing.T, datas ...ep.Data) {
+	typee := datas[0].Type()
+
+	t.Run("TestDataBuilder_"+typee.String(), func(t *testing.T) {
+		builder := typee.Builder()
+
+		for _, d := range datas {
+			builder.Append(d)
+		}
+
+		res := builder.Data()
+
+		var expected ep.Data
+		for _, d := range datas {
+			if expected == nil {
+				expected = d
+			} else {
+				expected = expected.Append(d)
+			}
+		}
+
+		require.Equal(t, expected.Strings(), res.Strings())
+	})
+}

--- a/eptest/data.go
+++ b/eptest/data.go
@@ -201,10 +201,10 @@ func VerifyDataNullsHandling(t *testing.T, data ep.Data, expectedNullString stri
 // VerifyDataBuilder makes sure DataBuilder works on a given type
 func VerifyDataBuilder(t *testing.T, data ep.Data) {
 	typee := data.Type()
+	data.MarkNull(0)
 
 	t.Run("single append", func(t *testing.T) {
 		builder := typee.Builder()
-		data.MarkNull(0)
 
 		builder.Append(data)
 		res := builder.Data()
@@ -215,16 +215,10 @@ func VerifyDataBuilder(t *testing.T, data ep.Data) {
 
 	t.Run("multiple appends", func(t *testing.T) {
 		builder := typee.Builder()
-		data.MarkNull(0)
 
+		builder.Append(data)
 		builder.Append(data)
 		res := builder.Data()
-		require.Equal(t, typee, res.Type())
-		require.Equal(t, data.Strings(), res.Strings())
-		require.True(t, res.IsNull(0))
-
-		builder.Append(data)
-		res = builder.Data()
 		require.Equal(t, typee, res.Type())
 		require.Equal(t, data.Len()*2, res.Len())
 		require.True(t, res.IsNull(0))

--- a/eptest/data.go
+++ b/eptest/data.go
@@ -204,15 +204,19 @@ func VerifyDataBuilder(t *testing.T, data ep.Data) {
 	builder := typee.Builder()
 	data.MarkNull(0)
 
-	builder.Append(data)
-	res := builder.Data()
-	require.Equal(t, data.Strings(), res.Strings())
-	require.True(t, res.IsNull(0), "first row should be null")
+	t.Run("single append", func(t *testing.T) {
+		builder.Append(data)
+		res := builder.Data()
+		require.Equal(t, data.Strings(), res.Strings())
+		require.True(t, res.IsNull(0))
+	})
 
-	builder.Append(data)
-	res = builder.Data()
-	require.Equal(t, data.Len()*2, res.Len())
-	require.True(t, res.IsNull(0))
-	require.True(t, res.IsNull(data.Len()))
-	require.Equal(t, append(data.Strings(), data.Strings()...), res.Strings())
+	t.Run("multiple appends", func(t *testing.T) {
+		builder.Append(data)
+		res := builder.Data()
+		require.Equal(t, data.Len()*2, res.Len())
+		require.True(t, res.IsNull(0))
+		require.True(t, res.IsNull(data.Len()))
+		require.Equal(t, append(data.Strings(), data.Strings()...), res.Strings())
+	})
 }

--- a/eptest/data.go
+++ b/eptest/data.go
@@ -207,6 +207,7 @@ func VerifyDataBuilder(t *testing.T, data ep.Data) {
 	t.Run("single append", func(t *testing.T) {
 		builder.Append(data)
 		res := builder.Data()
+		require.Equal(t, typee, res.Type())
 		require.Equal(t, data.Strings(), res.Strings())
 		require.True(t, res.IsNull(0))
 	})
@@ -214,6 +215,7 @@ func VerifyDataBuilder(t *testing.T, data ep.Data) {
 	t.Run("multiple appends", func(t *testing.T) {
 		builder.Append(data)
 		res := builder.Data()
+		require.Equal(t, typee, res.Type())
 		require.Equal(t, data.Len()*2, res.Len())
 		require.True(t, res.IsNull(0))
 		require.True(t, res.IsNull(data.Len()))

--- a/eptest/data.go
+++ b/eptest/data.go
@@ -201,10 +201,11 @@ func VerifyDataNullsHandling(t *testing.T, data ep.Data, expectedNullString stri
 // VerifyDataBuilder makes sure DataBuilder works on a given type
 func VerifyDataBuilder(t *testing.T, data ep.Data) {
 	typee := data.Type()
-	builder := typee.Builder()
-	data.MarkNull(0)
 
 	t.Run("single append", func(t *testing.T) {
+		builder := typee.Builder()
+		data.MarkNull(0)
+
 		builder.Append(data)
 		res := builder.Data()
 		require.Equal(t, typee, res.Type())
@@ -213,8 +214,17 @@ func VerifyDataBuilder(t *testing.T, data ep.Data) {
 	})
 
 	t.Run("multiple appends", func(t *testing.T) {
+		builder := typee.Builder()
+		data.MarkNull(0)
+
 		builder.Append(data)
 		res := builder.Data()
+		require.Equal(t, typee, res.Type())
+		require.Equal(t, data.Strings(), res.Strings())
+		require.True(t, res.IsNull(0))
+
+		builder.Append(data)
+		res = builder.Data()
 		require.Equal(t, typee, res.Type())
 		require.Equal(t, data.Len()*2, res.Len())
 		require.True(t, res.IsNull(0))

--- a/type.go
+++ b/type.go
@@ -75,8 +75,8 @@ func (*wildcardType) Name() string               { return "*" }
 func (*wildcardType) Size() uint                 { panic("wildcard has no concrete type") }
 func (*wildcardType) Data(int) Data              { panic("wildcard has no concrete type") }
 func (*wildcardType) DataEmpty(int) Data         { panic("wildcard has no concrete type") }
-func (w *wildcardType) At(idx int) *wildcardType { return &wildcardType{&idx, w.CutFromTail} }
 func (w *wildcardType) DataBuilder() DataBuilder { panic("wildcard has no concrete type") }
+func (w *wildcardType) At(idx int) *wildcardType { return &wildcardType{&idx, w.CutFromTail} }
 
 type anyType struct{}
 

--- a/type.go
+++ b/type.go
@@ -44,9 +44,9 @@ type Type interface {
 	// DataEmpty returns a new empty Data object of this type, with allocated size 'n'
 	DataEmpty(n int) Data
 
-	// DataBuilder returns a new DataBuilder object to efficiently append Data
+	// Builder returns a new Builder object to efficiently append Data
 	// of this Type
-	DataBuilder() DataBuilder
+	Builder() DataBuilder
 }
 
 // AreEqualTypes compares types and returns true if types arrays are deep equal
@@ -75,17 +75,17 @@ func (*wildcardType) Name() string               { return "*" }
 func (*wildcardType) Size() uint                 { panic("wildcard has no concrete type") }
 func (*wildcardType) Data(int) Data              { panic("wildcard has no concrete type") }
 func (*wildcardType) DataEmpty(int) Data         { panic("wildcard has no concrete type") }
-func (w *wildcardType) DataBuilder() DataBuilder { panic("wildcard has no concrete type") }
+func (w *wildcardType) Builder() DataBuilder     { panic("wildcard has no concrete type") }
 func (w *wildcardType) At(idx int) *wildcardType { return &wildcardType{&idx, w.CutFromTail} }
 
 type anyType struct{}
 
-func (*anyType) String() string           { return "?" }
-func (*anyType) Name() string             { return "?" }
-func (*anyType) Size() uint               { panic("any has no concrete type") }
-func (*anyType) Data(int) Data            { panic("any has no concrete type") }
-func (*anyType) DataEmpty(int) Data       { panic("any has no concrete type") }
-func (*anyType) DataBuilder() DataBuilder { panic("any has no concrete type") }
+func (*anyType) String() string       { return "?" }
+func (*anyType) Name() string         { return "?" }
+func (*anyType) Size() uint           { panic("any has no concrete type") }
+func (*anyType) Data(int) Data        { panic("any has no concrete type") }
+func (*anyType) DataEmpty(int) Data   { panic("any has no concrete type") }
+func (*anyType) Builder() DataBuilder { panic("any has no concrete type") }
 func isAny(t Type) bool {
 	return t.Name() == "?"
 }

--- a/type.go
+++ b/type.go
@@ -43,6 +43,10 @@ type Type interface {
 
 	// DataEmpty returns a new empty Data object of this type, with allocated size 'n'
 	DataEmpty(n int) Data
+
+	// DataBuilder returns a new DataBuilder object to efficiently append Data
+	// of this Type
+	DataBuilder() DataBuilder
 }
 
 // AreEqualTypes compares types and returns true if types arrays are deep equal
@@ -72,14 +76,16 @@ func (*wildcardType) Size() uint                 { panic("wildcard has no concre
 func (*wildcardType) Data(int) Data              { panic("wildcard has no concrete type") }
 func (*wildcardType) DataEmpty(int) Data         { panic("wildcard has no concrete type") }
 func (w *wildcardType) At(idx int) *wildcardType { return &wildcardType{&idx, w.CutFromTail} }
+func (w *wildcardType) DataBuilder() DataBuilder { panic("wildcard has no concrete type") }
 
 type anyType struct{}
 
-func (*anyType) String() string     { return "?" }
-func (*anyType) Name() string       { return "?" }
-func (*anyType) Size() uint         { panic("any has no concrete type") }
-func (*anyType) Data(int) Data      { panic("any has no concrete type") }
-func (*anyType) DataEmpty(int) Data { panic("any has no concrete type") }
+func (*anyType) String() string           { return "?" }
+func (*anyType) Name() string             { return "?" }
+func (*anyType) Size() uint               { panic("any has no concrete type") }
+func (*anyType) Data(int) Data            { panic("any has no concrete type") }
+func (*anyType) DataEmpty(int) Data       { panic("any has no concrete type") }
+func (*anyType) DataBuilder() DataBuilder { panic("any has no concrete type") }
 func isAny(t Type) bool {
 	return t.Name() == "?"
 }


### PR DESCRIPTION
[Task](https://app.asana.com/0/573768021211412/987829874929256/f)

This PR adds a new `DataBuilder` interface and extends `Type` interface to support it. It also contains a `DataBuilder` implementation for `dataset` type, which uses underlying `Data`'s `DataBuilder` jobjects.

These are some benchmarks I wrote to compare our current `Append` performance vs `DataBuilder`:
```
BenchmarkDataBuilder/integer/DataBuilder-4                 10000            124918 ns/op          809176 B/op         14 allocs/op
BenchmarkDataBuilder/integer/Append-4                       3000            483025 ns/op         4593611 B/op        121 allocs/op

BenchmarkDataBuilder/string/DataBuilder-4                   2000            747980 ns/op         1611994 B/op         14 allocs/op
BenchmarkDataBuilder/string/Append-4                         300           5394440 ns/op         9178448 B/op        122 allocs/op

BenchmarkDataBuilder/both/DataBuilder-4                     2000           1125124 ns/op         2425209 B/op         37 allocs/op
BenchmarkDataBuilder/both/Append-4                           300           5759933 ns/op        13778224 B/op        438 allocs/op
```