### PR TITLE
add AliasSetter interface

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -15,8 +15,8 @@ type AliasSetter interface {
 // Useful for planners that need to externally wrap a runner with alias
 // see Aliasing and Scoping
 func Alias(r Runner, label string) Runner {
-	if cmp, ok := r.(*compose); ok {
-		cmp.Ts[0] = SetAlias(cmp.Ts[0], label)
+	if setter, ok := r.(AliasSetter); ok {
+		setter.SetAlias(label)
 		return r
 	}
 	return &alias{r, label}

--- a/alias.go
+++ b/alias.go
@@ -6,6 +6,7 @@ var _ = registerGob(&scope{})
 // UnnamedColumn used as default name for columns without an alias
 const UnnamedColumn = "?column?"
 
+// AliasSetter interface for adding alias inside runner
 type AliasSetter interface {
 	SetAlias(name string)
 }

--- a/alias.go
+++ b/alias.go
@@ -6,7 +6,7 @@ var _ = registerGob(&scope{})
 // UnnamedColumn used as default name for columns without an alias
 const UnnamedColumn = "?column?"
 
-// AliasSetter interface for adding alias inside runner
+// AliasSetter interface allows to set alias on returned column within the runner
 type AliasSetter interface {
 	SetAlias(name string)
 }

--- a/alias.go
+++ b/alias.go
@@ -6,6 +6,10 @@ var _ = registerGob(&scope{})
 // UnnamedColumn used as default name for columns without an alias
 const UnnamedColumn = "?column?"
 
+type AliasSetter interface {
+	SetAlias(name string)
+}
+
 // Alias wraps given runner's single return type with given alias.
 // Useful for planners that need to externally wrap a runner with alias
 // see Aliasing and Scoping

--- a/composition.go
+++ b/composition.go
@@ -73,6 +73,9 @@ func (c *compose) Scopes() StringsSet {
 }
 
 func (c *compose) SetAlias(name string) {
+	if len(c.Ts) > 1 {
+		panic("Invalid usage of alias. Consider use scope")
+	}
 	c.Ts[0] = SetAlias(c.Ts[0], name)
 }
 

--- a/composition.go
+++ b/composition.go
@@ -72,6 +72,10 @@ func (c *compose) Scopes() StringsSet {
 	return scopes
 }
 
+func (c *compose) SetAlias(name string) {
+	c.Ts[0] = SetAlias(c.Ts[0], name)
+}
+
 // ComposeProject returns a special Composable which forwards its input as-is
 // to every Composable's BatchFunction, combining their outputs into a single
 // Dataset. It is a functional implementation of ep.Project.

--- a/exchange_partition.go
+++ b/exchange_partition.go
@@ -37,7 +37,8 @@ func (ex *exchange) encodePartition(e interface{}) error {
 
 	lastSeenHash := ex.getRowHash(stringValues, 0)
 	lastSlicedRow := 0
-	for row := 1; row < data.Len(); row++ {
+	len := data.Len()
+	for row := 1; row < len; row++ {
 		hash := ex.getRowHash(stringValues, row)
 		if hash == lastSeenHash {
 			continue
@@ -54,7 +55,7 @@ func (ex *exchange) encodePartition(e interface{}) error {
 	}
 
 	// leftover
-	dataToEncode := data.Slice(lastSlicedRow, data.Len())
+	dataToEncode := data.Slice(lastSlicedRow, len)
 	return ex.partitionData(dataToEncode, lastSeenHash)
 }
 


### PR DESCRIPTION
[asana](https://app.asana.com/0/573768021211412/992588584934659)

add AliasSetter interface to allow setting alias within runner without wrapping it with `alias` runner. (following https://github.com/panoplyio/epsilon/pull/304#discussion_r257580448)