### PR TITLE
Remove Append and DataEmpty from ep.Data and ep.Type interfaces

### DIFF
--- a/data.go
+++ b/data.go
@@ -10,9 +10,9 @@ import (
 // NOTES:
 // 1. all indices received as arguments should be in range [0, Len())
 // 2. besides Equal, all Data received as arguments should have same type as this
-// 3. mutable functions (MarkNull, Swap, Copy, Append) should be called only within
-//    creation scope or at gathering point. i.e. when no other runner have access
-//    to this object. not following this rule will end up with data race
+// 3. mutable functions (MarkNull, Swap, Copy) should be called only within
+//    creation scope or at gathering point, i.e when no other runners have access
+//    to this object. Not following this rule will end up with data race
 type Data interface {
 	// Type returns the data type of the contained values
 	Type() Type

--- a/data.go
+++ b/data.go
@@ -27,11 +27,6 @@ type Data interface {
 	// to end indices
 	Slice(start, end int) Data
 
-	// Append takes another data object and appends it to this one.
-	// It can be assumed that the type of the input data is similar
-	// to the current one, otherwise it's safe to panic
-	Append(other Data) Data
-
 	// Duplicate returns new data object containing this object t
 	// times. returned value has Len() * t rows
 	Duplicate(t int) Data

--- a/data_builder_test.go
+++ b/data_builder_test.go
@@ -37,71 +37,35 @@ func BenchmarkDataBuilder(b *testing.B) {
 	}
 
 	b.Run("integer", func(b *testing.B) {
-		b.Run("DataBuilder", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				db := integer.Builder()
-				for j := 0; j < len(dataInts); j++ {
-					db.Append(dataInts[j])
-				}
-				data := db.Data()
-				require.Equal(b, 100*1000, data.Len())
+		for i := 0; i < b.N; i++ {
+			db := integer.Builder()
+			for j := 0; j < len(dataInts); j++ {
+				db.Append(dataInts[j])
 			}
-		})
-
-		b.Run("Append", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				data := dataInts[0].Type().Data(0)
-				for j := 0; j < len(dataInts); j++ {
-					data = data.Append(dataInts[j])
-				}
-				require.Equal(b, 100*1000, data.Len())
-			}
-		})
+			data := db.Data()
+			require.Equal(b, 100*1000, data.Len())
+		}
 	})
 
 	b.Run("string", func(b *testing.B) {
-		b.Run("DataBuilder", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				db := str.Builder()
-				for j := 0; j < len(dataStrs); j++ {
-					db.Append(dataStrs[j])
-				}
-				data := db.Data()
-				require.Equal(b, 100*1000, data.Len())
+		for i := 0; i < b.N; i++ {
+			db := str.Builder()
+			for j := 0; j < len(dataStrs); j++ {
+				db.Append(dataStrs[j])
 			}
-		})
-
-		b.Run("Append", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				data := dataStrs[0].Type().Data(0)
-				for j := 0; j < len(dataStrs); j++ {
-					data = data.Append(dataStrs[j])
-				}
-				require.Equal(b, 100*1000, data.Len())
-			}
-		})
+			data := db.Data()
+			require.Equal(b, 100*1000, data.Len())
+		}
 	})
 
 	b.Run("both", func(b *testing.B) {
-		b.Run("DataBuilder", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				db := ep.NewDatasetBuilder()
-				for j := 0; j < len(dataBoth); j++ {
-					db.Append(dataBoth[j])
-				}
-				data := db.Data()
-				require.Equal(b, 100*1000, data.Len())
+		for i := 0; i < b.N; i++ {
+			db := ep.NewDatasetBuilder()
+			for j := 0; j < len(dataBoth); j++ {
+				db.Append(dataBoth[j])
 			}
-		})
-
-		b.Run("Append", func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				var data ep.Data = ep.NewDataset()
-				for j := 0; j < len(dataBoth); j++ {
-					data = data.Append(dataBoth[j])
-				}
-				require.Equal(b, 100*1000, data.Len())
-			}
-		})
+			data := db.Data()
+			require.Equal(b, 100*1000, data.Len())
+		}
 	})
 }

--- a/data_example_test.go
+++ b/data_example_test.go
@@ -17,11 +17,10 @@ var integer = &integerType{}
 
 type strType struct{}
 
-func (s *strType) String() string        { return s.Name() }
-func (*strType) Name() string            { return "string" }
-func (*strType) Size() uint              { return 8 }
-func (*strType) Data(n int) ep.Data      { return make(strs, n) }
-func (*strType) DataEmpty(n int) ep.Data { return make(strs, 0, n) }
+func (s *strType) String() string   { return s.Name() }
+func (*strType) Name() string       { return "string" }
+func (*strType) Size() uint         { return 8 }
+func (*strType) Data(n int) ep.Data { return make(strs, n) }
 func (*strType) Builder() ep.DataBuilder {
 	return &strBuilder{}
 }
@@ -99,11 +98,10 @@ func (vs strs) Strings() []string { return vs }
 
 type integerType struct{}
 
-func (s *integerType) String() string        { return s.Name() }
-func (*integerType) Name() string            { return "integer" }
-func (*integerType) Size() uint              { return 4 }
-func (*integerType) Data(n int) ep.Data      { return make(integers, n) }
-func (*integerType) DataEmpty(n int) ep.Data { return make(integers, 0, n) }
+func (s *integerType) String() string   { return s.Name() }
+func (*integerType) Name() string       { return "integer" }
+func (*integerType) Size() uint         { return 4 }
+func (*integerType) Data(n int) ep.Data { return make(integers, n) }
 func (*integerType) Builder() ep.DataBuilder {
 	return &integerBuilder{}
 }

--- a/data_example_test.go
+++ b/data_example_test.go
@@ -55,8 +55,7 @@ func (vs strs) LessOther(thisRow int, other ep.Data, otherRow int) bool {
 	data := other.(strs)
 	return vs[thisRow] < data[otherRow]
 }
-func (vs strs) Slice(s, e int) ep.Data       { return vs[s:e] }
-func (vs strs) Append(other ep.Data) ep.Data { return append(vs, other.(strs)...) }
+func (vs strs) Slice(s, e int) ep.Data { return vs[s:e] }
 func (vs strs) Duplicate(t int) ep.Data {
 	ans := make(strs, 0, vs.Len()*t)
 	for i := 0; i < t; i++ {
@@ -138,8 +137,7 @@ func (vs integers) LessOther(thisRow int, other ep.Data, otherRow int) bool {
 	data := other.(integers)
 	return vs[thisRow] < data[otherRow]
 }
-func (vs integers) Slice(s, e int) ep.Data       { return vs[s:e] }
-func (vs integers) Append(other ep.Data) ep.Data { return append(vs, other.(integers)...) }
+func (vs integers) Slice(s, e int) ep.Data { return vs[s:e] }
 func (vs integers) Duplicate(t int) ep.Data {
 	ans := make(integers, 0, vs.Len()*t)
 	for i := 0; i < t; i++ {

--- a/dataset.go
+++ b/dataset.go
@@ -238,26 +238,6 @@ func (set dataset) Slice(start, end int) Data {
 	return res
 }
 
-// see Data.Append (assumed by interface spec to be a Dataset)
-func (set dataset) Append(other Data) Data {
-	if set == nil || len(set) == 0 {
-		return other.Duplicate(1) // never affect other
-	}
-	if other == nil {
-		return set
-	}
-	data := other.(dataset)
-	if len(set) != len(data) {
-		panic("Unable to append mismatching number of columns")
-	}
-
-	res := make(dataset, set.Width())
-	for i := range set {
-		res[i] = set[i].Append(data[i])
-	}
-	return res
-}
-
 // see Data.Duplicate. Returns a dataset
 func (set dataset) Duplicate(t int) Data {
 	if set == nil || len(set) == 0 {

--- a/dataset.go
+++ b/dataset.go
@@ -43,8 +43,7 @@ type datasetType struct{}
 func (sett *datasetType) String() string  { return sett.Name() }
 func (*datasetType) Name() string         { return "record" }
 func (*datasetType) Size() uint           { panic("call Size on each Data") }
-func (sett *datasetType) Data(n int) Data { return sett.DataEmpty(n) }
-func (*datasetType) DataEmpty(int) Data   { panic("use NewDataset function") }
+func (sett *datasetType) Data(n int) Data { panic("use NewDataset function") }
 func (*datasetType) Builder() DataBuilder { return NewDatasetBuilder() }
 
 type dataset []Data

--- a/dummy.go
+++ b/dummy.go
@@ -29,7 +29,6 @@ func (*variadicDummies) Less(int, int) bool            { return false }
 func (*variadicDummies) Swap(int, int)                 {}
 func (*variadicDummies) LessOther(int, Data, int) bool { return false }
 func (vs *variadicDummies) Slice(int, int) Data        { return vs }
-func (vs *variadicDummies) Append(Data) Data           { return vs }
 func (vs *variadicDummies) Duplicate(int) Data         { return vs }
 func (*variadicDummies) IsNull(int) bool               { return true }
 func (*variadicDummies) MarkNull(int)                  {}

--- a/dummy.go
+++ b/dummy.go
@@ -13,7 +13,6 @@ func (t *dummyType) String() string     { return t.Name() }
 func (*dummyType) Name() string         { return "dummy" }
 func (*dummyType) Size() uint           { return 0 }
 func (*dummyType) Data(int) Data        { return dummyData }
-func (*dummyType) DataEmpty(int) Data   { return dummyData }
 func (*dummyType) Builder() DataBuilder { return dummyBuilder }
 
 type dummyDataBuilder struct{}

--- a/ep_internal_test.go
+++ b/ep_internal_test.go
@@ -28,7 +28,6 @@ func (s *strType) String() string     { return s.Name() }
 func (*strType) Name() string         { return "string" }
 func (*strType) Size() uint           { return 8 }
 func (*strType) Data(n int) Data      { return make(strs, n) }
-func (*strType) DataEmpty(n int) Data { return make(strs, 0, n) }
 func (*strType) Builder() DataBuilder { return nil }
 
 type strs []string

--- a/ep_internal_test.go
+++ b/ep_internal_test.go
@@ -39,7 +39,6 @@ func (vs strs) Less(int, int) bool                     { return false }
 func (vs strs) Swap(int, int)                          {}
 func (vs strs) LessOther(int, Data, int) bool          { return false }
 func (vs strs) Slice(int, int) Data                    { return vs }
-func (vs strs) Append(Data) Data                       { return vs }
 func (vs strs) Duplicate(t int) Data                   { return vs }
 func (vs strs) IsNull(int) bool                        { return false }
 func (vs strs) MarkNull(int)                           {}

--- a/ep_test.go
+++ b/ep_test.go
@@ -225,10 +225,16 @@ type localSort struct {
 
 func (*localSort) Returns() []ep.Type { return []ep.Type{ep.Wildcard, str} }
 func (ls *localSort) Run(ctx context.Context, inp, out chan ep.Dataset) error {
-	var selfData ep.Data = ep.NewDataset()
+	builder := ep.NewDatasetBuilder()
+	hasData := false
 	// consume entire local input before sorting all together
 	for data := range inp {
-		selfData = selfData.Append(data)
+		builder.Append(data)
+		hasData = true
+	}
+	var selfData ep.Data
+	if hasData {
+		selfData = builder.Data()
 	}
 	size := selfData.Len()
 	if size > 0 {

--- a/eptest/data.go
+++ b/eptest/data.go
@@ -44,12 +44,6 @@ func VerifyDataInterfaceInvariant(t *testing.T, data ep.Data) {
 		require.Equal(t, dataString, fmt.Sprintf("%+v", data))
 	})
 
-	t.Run("TestData_Append_invariant_"+data.Type().String(), func(t *testing.T) {
-		data.Append(data)
-		require.Equal(t, oldLen, data.Len())
-		require.Equal(t, dataString, fmt.Sprintf("%+v", data))
-	})
-
 	t.Run("TestData_Duplicate_invariant_"+data.Type().String(), func(t *testing.T) {
 		data.Duplicate(5)
 		require.Equal(t, oldLen, data.Len())
@@ -151,12 +145,6 @@ func VerifyDataNullsHandling(t *testing.T, data ep.Data, expectedNullString stri
 	t.Run("TestData_Slice_withNulls_"+data.Type().String(), func(t *testing.T) {
 		slicedData := data.Slice(0, data.Len()/2)
 		require.True(t, slicedData.IsNull(nullIdx))
-	})
-
-	t.Run("TestData_Append_withNulls_"+data.Type().String(), func(t *testing.T) {
-		appendedData := data.Append(data)
-		require.True(t, appendedData.IsNull(nullIdx))
-		require.True(t, appendedData.IsNull(nullIdx+dataLength))
 	})
 
 	t.Run("TestData_Duplicate_withNulls_"+data.Type().String(), func(t *testing.T) {

--- a/eptest/eptest.go
+++ b/eptest/eptest.go
@@ -26,9 +26,14 @@ func RunWithContext(ctx context.Context, r ep.Runner, datasets ...ep.Dataset) (r
 		close(inp)
 	}()
 
-	res = ep.NewDataset()
+	builder := ep.NewDatasetBuilder()
+	hasData := false
 	for data := range out {
-		res = res.Append(data).(ep.Dataset)
+		builder.Append(data)
+		hasData = true
+	}
+	if hasData {
+		res = builder.Data().(ep.Dataset)
 	}
 	return res, err
 }

--- a/type.go
+++ b/type.go
@@ -41,9 +41,6 @@ type Type interface {
 	// Data returns a new Data object of this type, containing `n` zero-values
 	Data(n int) Data
 
-	// DataEmpty returns a new empty Data object of this type, with allocated size 'n'
-	DataEmpty(n int) Data
-
 	// Builder returns a new Builder object to efficiently append Data
 	// of this Type
 	Builder() DataBuilder
@@ -74,7 +71,6 @@ func (*wildcardType) String() string             { return "*" }
 func (*wildcardType) Name() string               { return "*" }
 func (*wildcardType) Size() uint                 { panic("wildcard has no concrete type") }
 func (*wildcardType) Data(int) Data              { panic("wildcard has no concrete type") }
-func (*wildcardType) DataEmpty(int) Data         { panic("wildcard has no concrete type") }
 func (w *wildcardType) Builder() DataBuilder     { panic("wildcard has no concrete type") }
 func (w *wildcardType) At(idx int) *wildcardType { return &wildcardType{&idx, w.CutFromTail} }
 
@@ -84,7 +80,6 @@ func (*anyType) String() string       { return "?" }
 func (*anyType) Name() string         { return "?" }
 func (*anyType) Size() uint           { panic("any has no concrete type") }
 func (*anyType) Data(int) Data        { panic("any has no concrete type") }
-func (*anyType) DataEmpty(int) Data   { panic("any has no concrete type") }
 func (*anyType) Builder() DataBuilder { panic("any has no concrete type") }
 func isAny(t Type) bool {
 	return t.Name() == "?"


### PR DESCRIPTION
[Task](https://app.asana.com/0/573768021211412/1110349877739578/f)

This PR removes deprecated `Append` method from `Data` interface. `DataBuilder` should be used instead.

This PR also removes `DataEmpty` method from `Type` interface since it is not needed anymore after `DataBuilder` introduction.