### PR TITLE
drain pipeline  inputs

### DIFF
--- a/distribute_test.go
+++ b/distribute_test.go
@@ -37,7 +37,7 @@ func TestDistributer_connectionError(t *testing.T) {
 
 // Test that errors are transmitted across the network
 func TestDistributer_Distribute_errorFromPeer(t *testing.T) {
-	mightErrored := &dataRunner{Dataset: ep.NewDataset(), ThrowOnData: ":5552"}
+	mightErrored := &dataRunner{ThrowOnData: ":5552"}
 	runner := ep.Pipeline(ep.Scatter(), &nodeAddr{}, mightErrored)
 
 	data1 := ep.NewDataset(strs{"hello", "world"})
@@ -46,7 +46,7 @@ func TestDistributer_Distribute_errorFromPeer(t *testing.T) {
 
 	require.Error(t, err)
 	require.Equal(t, "error :5552", err.Error())
-	require.Equal(t, 0, data.Width())
+	require.Equal(t, 2, data.Width())
 }
 
 func TestDistributer_Distribute_ignoreErrIgnorable(t *testing.T) {
@@ -54,8 +54,8 @@ func TestDistributer_Distribute_ignoreErrIgnorable(t *testing.T) {
 		name string
 		r    ep.Runner
 	}{
-		{name: "from peer", r: &dataRunner{Dataset: ep.NewDataset(str.Data(1)), ThrowOnData: ":5552", ThrowIgnorable: true}},
-		{name: "from master", r: &dataRunner{Dataset: ep.NewDataset(str.Data(1)), ThrowOnData: ":5551", ThrowIgnorable: true}},
+		{name: "from peer", r: &dataRunner{ThrowOnData: ":5552", ThrowIgnorable: true}},
+		{name: "from master", r: &dataRunner{ThrowOnData: ":5551", ThrowIgnorable: true}},
 	}
 
 	for _, tc := range tests {

--- a/ep_test.go
+++ b/ep_test.go
@@ -250,7 +250,7 @@ type runOther struct {
 	runner ep.Runner
 }
 
-func (*runOther) Returns() []ep.Type { return []ep.Type{ep.Wildcard} }
+func (r *runOther) Returns() []ep.Type { return r.runner.Returns() }
 func (r *runOther) Run(ctx context.Context, inp, out chan ep.Dataset) error {
 	innerInp := make(chan ep.Dataset)
 	innerOut := make(chan ep.Dataset)

--- a/ep_test.go
+++ b/ep_test.go
@@ -83,20 +83,13 @@ func (r *fixedData) Run(ctx context.Context, _, out chan ep.Dataset) (err error)
 }
 
 type dataRunner struct {
-	ep.Dataset
 	// ThrowOnData is a condition for throwing error. in case the last column
 	// contains exactly this string in first row - fail with error
 	ThrowOnData    string
 	ThrowIgnorable bool
 }
 
-func (r *dataRunner) Returns() []ep.Type {
-	var types []ep.Type
-	for i := 0; i < r.Dataset.Len(); i++ {
-		types = append(types, r.Dataset.At(i).Type())
-	}
-	return types
-}
+func (r *dataRunner) Returns() []ep.Type { return []ep.Type{ep.Wildcard} }
 func (r *dataRunner) Run(ctx context.Context, inp, out chan ep.Dataset) (err error) {
 	if r.ThrowIgnorable {
 		err = ep.ErrIgnorable
@@ -104,7 +97,7 @@ func (r *dataRunner) Run(ctx context.Context, inp, out chan ep.Dataset) (err err
 		err = fmt.Errorf("error %s", r.ThrowOnData)
 	}
 	for data := range inp {
-		out <- r.Dataset
+		out <- data
 		if r.ThrowOnData == data.At(data.Width() - 1).Strings()[0] {
 			return err
 		}

--- a/ep_test.go
+++ b/ep_test.go
@@ -248,10 +248,8 @@ func (ls *localSort) Run(ctx context.Context, inp, out chan ep.Dataset) error {
 	return nil
 }
 
-// un gob-able runners. should be used only for single peer tests
 type runOther struct {
 	runner ep.Runner
-	cancel context.CancelFunc
 }
 
 func (*runOther) Returns() []ep.Type { return []ep.Type{ep.Wildcard} }

--- a/ep_test.go
+++ b/ep_test.go
@@ -252,14 +252,16 @@ type runOther struct {
 	cancel context.CancelFunc
 }
 
+func (*runOther) Returns() []ep.Type { return []ep.Type{ep.Wildcard} }
 func (r *runOther) Run(ctx context.Context, inp, out chan ep.Dataset) error {
 	innerInp := make(chan ep.Dataset)
-	go r.runner.Run(ctx, innerInp, out)
+	var err error
+	go ep.Run(ctx, r.runner, innerInp, out, nil, &err)
 
 	for data := range inp {
 		innerInp <- data
 	}
-	return nil
+	for range out {
+	}
+	return err
 }
-
-func (*runOther) Returns() []ep.Type { return []ep.Type{ep.Wildcard} }

--- a/ep_test.go
+++ b/ep_test.go
@@ -263,4 +263,3 @@ func (r *runOther) Run(ctx context.Context, inp, out chan ep.Dataset) error {
 }
 
 func (*runOther) Returns() []ep.Type { return []ep.Type{ep.Wildcard} }
-

--- a/ep_test.go
+++ b/ep_test.go
@@ -97,9 +97,7 @@ func (r *dataRunner) Run(ctx context.Context, inp, out chan ep.Dataset) (err err
 		err = fmt.Errorf("error %s", r.ThrowOnData)
 	}
 	for data := range inp {
-		fmt.Println("dataRunner: b out <- data")
 		out <- data
-		fmt.Println("dataRunner: a out <- data")
 		if r.ThrowOnData == data.At(data.Width() - 1).Strings()[0] {
 			return err
 		}

--- a/exchange_sortgather_test.go
+++ b/exchange_sortgather_test.go
@@ -61,7 +61,7 @@ func TestSortGather(t *testing.T) {
 
 func TestSortGather_error(t *testing.T) {
 	runSortGather := func(t *testing.T, sortingCols []ep.SortingCol, datasets ...ep.Dataset) {
-		var runner ep.Runner = &dataRunner{Dataset: ep.NewDataset(strs{"str"}), ThrowOnData: "failed"}
+		var runner ep.Runner = &dataRunner{ThrowOnData: "failed"}
 		runner = ep.Pipeline(runner, ep.Scatter(), &nodeAddr{}, ep.SortGather(sortingCols))
 		_, err := eptest.RunDist(t, 2, runner, datasets...)
 		require.Error(t, err)

--- a/pipeline.go
+++ b/pipeline.go
@@ -96,6 +96,7 @@ func (rs pipeline) Run(ctx context.Context, inp, out chan Dataset) (err error) {
 func wrapInpWithCancel(ctx context.Context, inp chan Dataset) chan Dataset {
 	newInp := make(chan Dataset)
 	go func() {
+		defer drain(inp)
 		defer close(newInp)
 		for {
 			select {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -32,7 +32,7 @@ func ExamplePipeline_reverse() {
 }
 
 func TestPipeline_ignoreErrIgnorable(t *testing.T) {
-	runner := ep.Pipeline(&dataRunner{Dataset: ep.NewDataset(str.Data(1)), ThrowOnData: "ignore error", ThrowIgnorable: true}, &count{})
+	runner := ep.Pipeline(&dataRunner{ThrowOnData: "ignore error", ThrowIgnorable: true}, &count{})
 
 	data1 := ep.NewDataset(strs{"data"})
 	data2 := ep.NewDataset(strs{"ignore error"})
@@ -262,7 +262,7 @@ func runVerifyError(t *testing.T, runner ep.Runner, expected error) {
 func TestPipeline_errorFromExchange(t *testing.T) {
 	verifyExchangeError := func(t *testing.T, port string) {
 		infinityRunner := &waitForCancel{}
-		mightErrored := &dataRunner{Dataset: ep.NewDataset(str.Data(1)), ThrowOnData: port}
+		mightErrored := &dataRunner{ThrowOnData: port}
 		runner := ep.Pipeline(
 			infinityRunner,
 			ep.Scatter(),
@@ -294,8 +294,8 @@ func TestPipeline_multipleErrorsFromExchange(t *testing.T) {
 	verifyExchangeErrors := func(t *testing.T, port1, port2 string) {
 		infinityRunner1 := &waitForCancel{}
 		infinityRunner2 := &waitForCancel{}
-		err1 := &dataRunner{Dataset: ep.NewDataset(str.Data(1)), ThrowOnData: port1}
-		err2 := &dataRunner{Dataset: ep.NewDataset(str.Data(1)), ThrowOnData: port2}
+		err1 := &dataRunner{ThrowOnData: port1}
+		err2 := &dataRunner{ThrowOnData: port2}
 		runner := ep.Pipeline(
 			ep.Project(ep.PassThrough(), ep.Pipeline(&nodeAddr{}, err2)),
 			infinityRunner1,

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -338,7 +338,7 @@ func TestPipeline_drainOriginInput(t *testing.T) {
 
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
-	runner := &runOther{pipeline, cancel}
+	runner := &runOther{pipeline}
 
 	data := ep.NewDataset(strs{"data"})
 	inp := make(chan ep.Dataset)

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -331,3 +331,31 @@ func TestPipeline_multipleErrorsFromExchange(t *testing.T) {
 		verifyExchangeErrors(t, ":5551", ":5551")
 	})
 }
+
+func TestPipeline_drainOriginInput(t *testing.T) {
+	throwIgnorable := &dataRunner{ThrowOnData: "ignore error", ThrowIgnorable: true}
+	waitForExitData := &dataRunner{ThrowOnData: "exit", ThrowIgnorable: true}
+	externalInp := make(chan ep.Dataset)
+	dupWrites := &duplicateWrites{externalInp}
+	passThroughExternalInp := &passThroughExternalInp{externalInp}
+
+	cancelInnerPipe := make(chan bool)
+	notify := &notifyOnCancel{cancelInnerPipe}
+	waitForNotification := &waitForNotification{cancelInnerPipe}
+
+	runner := ep.Project(
+		dupWrites,
+		// pipeline will keep writing output but will not exit until project cancellation
+		ep.Pipeline(throwIgnorable, waitForNotification, passThroughExternalInp),
+		waitForExitData,
+		notify,
+	)
+
+	data1 := ep.NewDataset(strs{"data"})
+	data2 := ep.NewDataset(strs{"ignore error"})
+	data3 := ep.NewDataset(strs{"other data"})
+	data4 := ep.NewDataset(strs{"exit"})
+	_, err := eptest.Run(runner, data1, data2, data3, data3, data3, data4, data3)
+	require.Error(t, err)
+	require.EqualError(t, err, ep.ErrIgnorable.Error())
+}


### PR DESCRIPTION
[asana](https://app.asana.com/0/573768021211412/1111457154294716)

In case another runner that isn't listening to cancellation running an internal pipeline we should make sure that the inner pipeline will drain its input after the inner pipeline cancellation so the flow won't be stuck.

For more details, you can look in the asana task comments.