### PR TITLE
Fix pipeline ApproxSize implementation

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -194,10 +194,14 @@ func (rs pipeline) Push(toPush ScopesRunner) bool {
 }
 
 func (rs pipeline) ApproxSize() int {
-	lastIdx := len(rs) - 1
-	last := rs[lastIdx]
-	if approxSizer, ok := last.(ApproxSizer); ok {
-		return approxSizer.ApproxSize()
+	for i := len(rs) - 1; i >= 0; i-- {
+		r := rs[i]
+		if approxSizer, ok := r.(ApproxSizer); ok {
+			size := approxSizer.ApproxSize()
+			if size != UnknownSize {
+				return size
+			}
+		}
 	}
 	return UnknownSize
 }

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -105,14 +105,30 @@ func TestPipeline_Args_noArgs(t *testing.T) {
 
 func TestPipeline_ApproxSize(t *testing.T) {
 	t.Run("known size", func(t *testing.T) {
-		r := ep.Pipeline(&upper{}, &runnerWithSize{size: 42})
-		sizer, ok := r.(ep.ApproxSizer)
-		require.True(t, ok)
-		require.Equal(t, 42, sizer.ApproxSize())
+		t.Run("last runner", func(t *testing.T) {
+			r := ep.Pipeline(&upper{}, &runnerWithSize{size: 42})
+			sizer, ok := r.(ep.ApproxSizer)
+			require.True(t, ok)
+			require.Equal(t, 42, sizer.ApproxSize())
+		})
+
+		t.Run("middle runner", func(t *testing.T) {
+			r := ep.Pipeline(&upper{}, &runnerWithSize{size: 42}, &question{})
+			sizer, ok := r.(ep.ApproxSizer)
+			require.True(t, ok)
+			require.Equal(t, 42, sizer.ApproxSize())
+		})
+
+		t.Run("first runner", func(t *testing.T) {
+			r := ep.Pipeline(&runnerWithSize{size: 42}, &upper{}, &question{})
+			sizer, ok := r.(ep.ApproxSizer)
+			require.True(t, ok)
+			require.Equal(t, 42, sizer.ApproxSize())
+		})
 	})
 
 	t.Run("unknown size", func(t *testing.T) {
-		r := ep.Pipeline(&upper{}, &runnerWithSize{size: 42}, &question{})
+		r := ep.Pipeline(&upper{}, &question{})
 		sizer, ok := r.(ep.ApproxSizer)
 		require.True(t, ok)
 		require.Equal(t, ep.UnknownSize, sizer.ApproxSize())


### PR DESCRIPTION
[Task](https://app.asana.com/0/573768021211412/1107574389242163/f)

Pipeline needs to look not only at the latest runner to determine its
size, but to the previous runners as well, until a known size is found.