### PR TITLE
Group data by endpoints during partition

### DIFF
--- a/ep_internal_test.go
+++ b/ep_internal_test.go
@@ -24,11 +24,32 @@ var str = &strType{}
 
 type strType struct{}
 
-func (s *strType) String() string     { return s.Name() }
-func (*strType) Name() string         { return "string" }
-func (*strType) Size() uint           { return 8 }
-func (*strType) Data(n int) Data      { return make(strs, n) }
-func (*strType) Builder() DataBuilder { return nil }
+func (s *strType) String() string { return s.Name() }
+func (*strType) Name() string     { return "string" }
+func (*strType) Size() uint       { return 8 }
+func (*strType) Data(n int) Data  { return make(strs, n) }
+func (*strType) Builder() DataBuilder {
+	return &strBuilder{}
+}
+
+type strBuilder struct {
+	ds  []strs
+	len int
+}
+
+func (b *strBuilder) Append(data Data) {
+	strData := data.(strs)
+	b.ds = append(b.ds, strData)
+	b.len += strData.Len()
+}
+
+func (b *strBuilder) Data() Data {
+	res := make(strs, 0, b.len)
+	for _, d := range b.ds {
+		res = append(res, d...)
+	}
+	return res
+}
 
 type strs []string
 

--- a/exchange_partition.go
+++ b/exchange_partition.go
@@ -92,3 +92,21 @@ func (ex *exchange) getPartitionEncoder(key string) (encoder, error) {
 
 	return enc, nil
 }
+
+type dataWithEndpoints struct {
+	data      Dataset
+	endpoints []string
+}
+
+func (s *dataWithEndpoints) Len() int {
+	return len(s.endpoints)
+}
+
+func (s *dataWithEndpoints) Less(i int, j int) bool {
+	return s.endpoints[i] < s.endpoints[j]
+}
+
+func (s *dataWithEndpoints) Swap(i int, j int) {
+	s.data.Swap(i, j)
+	s.endpoints[i], s.endpoints[j] = s.endpoints[j], s.endpoints[i]
+}

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -288,24 +288,24 @@ func TestPartition(t *testing.T) {
 
 		require.Equal(t, expectedOutput, res.Strings())
 	})
-}
 
-func TestPartition_sendsCompleteDatasets(t *testing.T) {
-	firstColumn := strs{"foo", "bar", "meh", "nya", "shtoot", "a", "few", "more", "things"}
-	secondColumn := strs{"f", "s", "f", "f", "s", "f", "f", "f", "s"}
+	t.Run("sends complete datasets", func(t *testing.T) {
+		firstColumn := strs{"foo", "bar", "meh", "nya", "shtoot", "a", "few", "more", "things"}
+		secondColumn := strs{"f", "s", "f", "f", "s", "f", "f", "f", "s"}
 
-	data := ep.NewDataset(firstColumn, secondColumn)
-	runner := ep.Pipeline(ep.Partition(1), &count{})
+		data := ep.NewDataset(firstColumn, secondColumn)
+		runner := ep.Pipeline(ep.Partition(1), &count{})
 
-	res, err := eptest.RunDist(t, 2, runner, data)
-	require.NoError(t, err)
+		res, err := eptest.RunDist(t, 2, runner, data)
+		require.NoError(t, err)
 
-	// there are 6 "f" and 3 "s" in second column which is used for partitioning
-	expected := []string{"6", "3"}
-	sizes := res.At(0)
+		// there are 6 "f" and 3 "s" in second column which is used for partitioning
+		expected := []string{"6", "3"}
+		sizes := res.At(0)
 
-	require.Equal(t, 2, sizes.Len())
-	require.ElementsMatch(t, expected, sizes.Strings())
+		require.Equal(t, 2, sizes.Len())
+		require.ElementsMatch(t, expected, sizes.Strings())
+	})
 }
 
 // test that exchange runners act as passThrough when executed without a

--- a/exchange_test.go
+++ b/exchange_test.go
@@ -290,21 +290,48 @@ func TestPartition(t *testing.T) {
 	})
 
 	t.Run("sends complete datasets", func(t *testing.T) {
-		firstColumn := strs{"foo", "bar", "meh", "nya", "shtoot", "a", "few", "more", "things"}
-		secondColumn := strs{"f", "s", "f", "f", "s", "f", "f", "f", "s"}
+		t.Run("multiple rows", func(t *testing.T) {
+			// mappings with current hashing algorithm:
+			// r, t, f 5551
+			// s, z, x 5552
+			//
+			// despite difference in column values, all rows assigned
+			// to each node must arrive together, not separately
+			firstColumn := strs{"foo", "bar", "meh", "nya", "shtoot", "a", "few", "more", "things"}
+			secondColumn := strs{"r", "s", "t", "z", "f", "x", "r", "s", "f"}
 
-		data := ep.NewDataset(firstColumn, secondColumn)
-		runner := ep.Pipeline(ep.Partition(1), &count{})
+			data := ep.NewDataset(firstColumn, secondColumn)
+			runner := ep.Pipeline(ep.Partition(1), &count{})
 
-		res, err := eptest.RunDist(t, 2, runner, data)
-		require.NoError(t, err)
+			res, err := eptest.RunDist(t, 2, runner, data)
+			require.NoError(t, err)
 
-		// there are 6 "f" and 3 "s" in second column which is used for partitioning
-		expected := []string{"6", "3"}
-		sizes := res.At(0)
+			// node 5551 is supposed to receive 5 rows; 5552 - 4 rows
+			expected := []string{"5", "4"}
+			sizes := res.At(0)
 
-		require.Equal(t, 2, sizes.Len())
-		require.ElementsMatch(t, expected, sizes.Strings())
+			require.Equal(t, 2, sizes.Len())
+			require.ElementsMatch(t, expected, sizes.Strings())
+		})
+
+		t.Run("single row", func(t *testing.T) {
+			// r maps to 5551 with current hashing algorithm
+			firstColumn := strs{"foo"}
+			secondColumn := strs{"r"}
+
+			data := ep.NewDataset(firstColumn, secondColumn)
+			runner := ep.Pipeline(ep.Partition(1), &count{})
+
+			res, err := eptest.RunDist(t, 2, runner, data)
+			require.NoError(t, err)
+
+			// node 5551 is supposed to receive 5 rows; 5552 - 4 rows
+			expected := []string{"1"}
+			sizes := res.At(0)
+
+			require.Equal(t, 1, sizes.Len())
+			require.ElementsMatch(t, expected, sizes.Strings())
+		})
 	})
 }
 


### PR DESCRIPTION
[Task](https://app.asana.com/0/573768021211412/1113513046356670/f)

Prior to this change, `ep.Partition` sent every unique row to target nodes one by one, creating a lot of IO/CPU overhead. This PR changes `ep.Partition` implementation to split data into datasets per target node before sending. It means that every batch that arrives to partition will trigger at most N `Encode` calls, where N is the number of nodes.