### PR TITLE
 use composable when possible

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -78,7 +78,7 @@ func GetAlias(col Type) string {
 // see Aliasing and Scoping
 func Scope(r Runner, label string) Runner {
 	if cmp, ok := r.(*compose); ok {
-		cmp.Scope = label
+		cmp.RetScope = label
 		return r
 	}
 	return &scope{r, label}

--- a/alias.go
+++ b/alias.go
@@ -78,7 +78,7 @@ func GetAlias(col Type) string {
 // see Aliasing and Scoping
 func Scope(r Runner, label string) Runner {
 	if cmp, ok := r.(*compose); ok {
-		cmp.ReturnTs = SetScope(cmp.ReturnTs, label)
+		cmp.Scope = label
 		return r
 	}
 	return &scope{r, label}

--- a/compose.go
+++ b/compose.go
@@ -38,7 +38,7 @@ type compose struct {
 
 func (c *compose) Returns() []Type {
 	last := len(c.Cmps) - 1
-	ret := returnsOne(c.Cmps[last], last, c.getPrev)
+	ret := returnsOne(last, c.getIReturns)
 
 	if c.Alias != "" {
 		if len(ret) > 1 {
@@ -51,7 +51,7 @@ func (c *compose) Returns() []Type {
 	}
 	return ret
 }
-func (c *compose) getPrev(j int) returns { return c.Cmps[j-1] }
+func (c *compose) getIReturns(i int) returns { return c.Cmps[i] }
 
 func (c *compose) Run(ctx context.Context, inp, out chan Dataset) error {
 	batchFunction := c.BatchFunction()

--- a/compose.go
+++ b/compose.go
@@ -19,14 +19,13 @@ type Composable interface {
 	BatchFunction() BatchFunction
 }
 
-// Compose returns a Runner with the provided return types & the provided scopes.
+// Compose returns a Runner with the the provided scopes.
 // Note: The caller's responsibility to maintain a valid set of scopes.
 // This Runner passes its input through every Composable's BatchFunction
 // implementation, where every following BatchFunction receives the output
 // of the previous one. This Runner is also a Composable, which means that
 // its BatchFunction can be retrieved and used in another Compose call.
-// TODO avia
-func Compose(returns []Type, scopes StringsSet, cmps ...Composable) Runner {
+func Compose(scopes StringsSet, cmps ...Composable) Runner {
 	return &compose{Scps: scopes, Cmps: cmps}
 }
 
@@ -169,17 +168,14 @@ func createComposeRunner(runners []Runner) (Runner, bool) {
 			return nil, false
 		}
 	}
-	retTypes := pipeline(runners).Returns()
-	return Compose(retTypes, scopes, cmps...), true
+	return Compose(scopes, cmps...), true
 }
 
 func createComposeProjectRunner(runners []Runner) (Runner, bool) {
 	var ok bool
-	var retTypes []Type
 	scopes := make(StringsSet)
 	cmps := make([]Composable, len(runners))
 	for i, r := range runners {
-		retTypes = append(retTypes, r.Returns()...)
 		if scp, ok := r.(ScopesRunner); ok {
 			scopes.AddAll(scp.Scopes())
 		}
@@ -187,5 +183,5 @@ func createComposeProjectRunner(runners []Runner) (Runner, bool) {
 			return nil, false
 		}
 	}
-	return Compose(retTypes, scopes, ComposeProject(cmps...)), true
+	return Compose(scopes, ComposeProject(cmps...)), true
 }

--- a/compose.go
+++ b/compose.go
@@ -30,10 +30,10 @@ func Compose(scopes StringsSet, cmps ...Composable) Runner {
 }
 
 type compose struct {
-	Alias string
-	Scope string
-	Scps  StringsSet
-	Cmps  []Composable
+	Alias    string
+	RetScope string
+	Scps     StringsSet
+	Cmps     []Composable
 }
 
 func (c *compose) Returns() []Type {
@@ -46,8 +46,8 @@ func (c *compose) Returns() []Type {
 		}
 		ret[0] = SetAlias(ret[0], c.Alias)
 	}
-	if c.Scope != "" {
-		ret = SetScope(ret, c.Scope)
+	if c.RetScope != "" {
+		ret = SetScope(ret, c.RetScope)
 	}
 	return ret
 }

--- a/compose.go
+++ b/compose.go
@@ -192,7 +192,7 @@ func createComposeProjectRunner(runners []Runner) (Runner, bool) {
 	return Compose(scopes, ComposeProject(flat...)), true
 }
 
-func isComposeProject(r Runner) (composeProject, bool) {
+func isComposeProject(r returns) (composeProject, bool) {
 	comp, isCmp := r.(*compose)
 	if isCmp && len(comp.Cmps) == 1 {
 		p, isProject := comp.Cmps[0].(composeProject)

--- a/compose_test.go
+++ b/compose_test.go
@@ -17,7 +17,6 @@ func TestCompose(t *testing.T) {
 
 	t.Run("single Composable", func(t *testing.T) {
 		runner := ep.Compose(
-			[]ep.Type{integer},
 			ep.StringsSet{"a": struct{}{}},
 			&addInts{},
 		)
@@ -33,7 +32,6 @@ func TestCompose(t *testing.T) {
 
 	t.Run("multiple Composables", func(t *testing.T) {
 		runner := ep.Compose(
-			[]ep.Type{integer},
 			ep.StringsSet{"b": struct{}{}},
 			&addInts{}, &negateInt{},
 		)

--- a/ep_test.go
+++ b/ep_test.go
@@ -284,3 +284,13 @@ func (r *runOther) Run(ctx context.Context, inp, out chan ep.Dataset) error {
 	wg.Wait()
 	return err
 }
+
+type runnerWithSize struct {
+	ep.Runner
+	size int
+}
+
+func (r *runnerWithSize) Returns() []ep.Type { return []ep.Type{ep.Wildcard} }
+func (r *runnerWithSize) ApproxSize() int {
+	return r.size
+}

--- a/ep_test.go
+++ b/ep_test.go
@@ -174,6 +174,7 @@ func (q *question) Run(_ context.Context, inp, out chan ep.Dataset) error {
 
 type addInts struct{}
 
+func (*addInts) Returns() []ep.Type { return []ep.Type{integer} }
 func (*addInts) BatchFunction() ep.BatchFunction {
 	return func(data ep.Dataset) (ep.Dataset, error) {
 		d0 := data.At(0).(integers)
@@ -188,6 +189,7 @@ func (*addInts) BatchFunction() ep.BatchFunction {
 
 type negateInt struct{}
 
+func (*negateInt) Returns() []ep.Type { return []ep.Type{integer} }
 func (*negateInt) BatchFunction() ep.BatchFunction {
 	return func(data ep.Dataset) (ep.Dataset, error) {
 		d0 := data.At(0).(integers)
@@ -201,6 +203,7 @@ func (*negateInt) BatchFunction() ep.BatchFunction {
 
 type mulIntBy2 struct{}
 
+func (*mulIntBy2) Returns() []ep.Type { return []ep.Type{integer} }
 func (*mulIntBy2) BatchFunction() ep.BatchFunction {
 	return func(data ep.Dataset) (ep.Dataset, error) {
 		d0 := data.At(0).(integers)

--- a/pipeline.go
+++ b/pipeline.go
@@ -40,6 +40,10 @@ func Pipeline(runners ...Runner) Runner {
 	} else if len(filtered) == 1 {
 		return filtered[0] // only one runner left, no need for a pipeline
 	}
+
+	if cmp, ok := createComposeRunner(runners); ok {
+		return cmp
+	}
 	return filtered
 }
 
@@ -159,13 +163,7 @@ func (rs pipeline) returnsOne(j int) []Type {
 }
 
 func (rs pipeline) Filter(keep []bool) {
-	lastIdx := len(rs) - 1
-	last := rs[lastIdx]
-	// pipeline contains at least 2 runners.
-	// if last is exchange, filter its input (i.e. one runner before last)
-	if _, isExchanger := last.(*exchange); isExchanger {
-		last = rs[lastIdx-1]
-	}
+	last := rs[len(rs)-1]
 	if f, isFilterable := last.(FilterRunner); isFilterable {
 		f.Filter(keep)
 	}

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -83,26 +83,32 @@ func TestPipeline_creationSingleRunnerAfterFlat(t *testing.T) {
 }
 
 func TestPipeline_creationComposable(t *testing.T) {
-	nestedPipeline := Pipeline(PassThrough(), Pipeline(&dummyRunner{}, PassThrough()), PassThrough())
-	_, isCmp := nestedPipeline.(Composable)
-	require.True(t, isCmp)
+	t.Run("nestedPipeline", func(t *testing.T) {
+		nestedPipeline := Pipeline(PassThrough(), Pipeline(&dummyRunner{}, PassThrough()), PassThrough())
+		_, isCmp := nestedPipeline.(Composable)
+		require.True(t, isCmp)
+	})
 
-	nestedComposablePipeline := Pipeline(
-		Pipeline(&dummyRunner{}, &dummyRunner{}),
-		Pipeline(&dummyRunner{}, &dummyRunner{}, passThroughSingleton),
-	)
+	t.Run("nestedComposablePipeline", func(t *testing.T) {
+		nestedComposablePipeline := Pipeline(
+			Pipeline(&dummyRunner{}, &dummyRunner{}),
+			Pipeline(&dummyRunner{}, &dummyRunner{}, passThroughSingleton),
+		)
 
-	c, isCmp := nestedComposablePipeline.(*compose)
-	require.True(t, isCmp)
-	require.Equal(t, 2, len(c.Cmps))
+		c, isCmp := nestedComposablePipeline.(*compose)
+		require.True(t, isCmp)
+		require.Equal(t, 2, len(c.Cmps))
+	})
 
-	pipelineWithProject := Pipeline(&dummyRunner{}, Compose(nil, ComposeProject(passThroughSingleton, &dummyRunner{})))
-	c, isCmp = pipelineWithProject.(*compose)
-	require.True(t, isCmp)
-	require.Equal(t, 2, len(c.Cmps))
-	p, isCmp := isComposeProject(c.Cmps[1])
-	require.True(t, isCmp)
-	require.Equal(t, 2, len(p))
+	t.Run("pipelineWithProject", func(t *testing.T) {
+		pipelineWithProject := Pipeline(&dummyRunner{}, Compose(nil, ComposeProject(passThroughSingleton, &dummyRunner{})))
+		c, isCmp := pipelineWithProject.(*compose)
+		require.True(t, isCmp)
+		require.Equal(t, 2, len(c.Cmps))
+		p, isCmp := isComposeProject(c.Cmps[1])
+		require.True(t, isCmp)
+		require.Equal(t, 2, len(p))
+	})
 }
 
 // Measures the number of datasets (ops) per second going through a pipeline

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -112,15 +112,13 @@ func TestPipeline_creationComposable(t *testing.T) {
 func BenchmarkPipeline(b *testing.B) {
 	run := func(r Runner) func(b *testing.B) {
 		return func(b *testing.B) {
+			var err error
+
 			data := NewDataset(dummy.Data(-1))
 			inp := make(chan Dataset)
 			out := make(chan Dataset)
 
-			go func() {
-				var err error
-				Run(context.Background(), r, inp, out, nil, &err)
-				require.NoError(b, err)
-			}()
+			go Run(context.Background(), r, inp, out, nil, &err)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -130,6 +128,8 @@ func BenchmarkPipeline(b *testing.B) {
 			}
 			close(inp)
 			drain(out)
+
+			require.NoError(b, err)
 		}
 	}
 	b.Run("runner", func(b *testing.B) {

--- a/plan.go
+++ b/plan.go
@@ -44,6 +44,10 @@ func PlanList(ctx context.Context, items []interface{}) ([]Runner, error) {
 
 		if p, ok := r.(project); ok {
 			runners = append(runners, p...)
+		} else if p, ok := isComposeProject(r); ok {
+			for _, cmp := range p {
+				runners = append(runners, cmp.(Runner))
+			}
 		} else {
 			runners = append(runners, r)
 		}

--- a/project.go
+++ b/project.go
@@ -29,7 +29,9 @@ func Project(runners ...Runner) Runner {
 	} else if len(flat) == 1 {
 		return runners[0]
 	}
-
+	if cmpProj, ok := createComposeProjectRunner(runners); ok {
+		return cmpProj
+	}
 	return flat
 }
 
@@ -232,4 +234,7 @@ func (*dummyRunner) Args() []Type    { return []Type{Wildcard} }
 func (*dummyRunner) Returns() []Type { return []Type{dummy} }
 func (*dummyRunner) Run(_ context.Context, inp, out chan Dataset) error {
 	return nil
+}
+func (*dummyRunner) BatchFunction() BatchFunction {
+	return func(Dataset) (Dataset, error) { return variadicDummiesBatch, nil }
 }

--- a/project_internal_test.go
+++ b/project_internal_test.go
@@ -46,3 +46,18 @@ func TestProject_creationPreservePipeline(t *testing.T) {
 	require.True(t, isProject)
 	require.Equal(t, 2, len(p))
 }
+
+func TestProject_creationFlatComposable(t *testing.T) {
+	runner := Project(
+		Project(&dummyRunner{}, &dummyRunner{}),
+		Project(PassThrough(), Pipeline(&dummyRunner{}, &dummyRunner{})),
+		PassThrough(),
+	)
+
+	p, isCmpProject := isComposeProject(runner)
+	require.True(t, isCmpProject)
+	require.Equal(t, 5, len(p))
+
+	_, isProject := isComposeProject(p[0])
+	require.False(t, isProject)
+}

--- a/runner_example_test.go
+++ b/runner_example_test.go
@@ -36,21 +36,10 @@ func ExampleScopesRunner_Scopes() {
 	// map[upper_scope:{}]
 }
 
-func ExampleApproxSizer() {
+func ExampleApproxSizer_ApproxSize() {
 	var runner ep.Runner = &runnerWithSize{size: 42}
 	fmt.Println(runner.(ep.ApproxSizer).ApproxSize())
 
 	// Output:
 	// 42
-}
-
-type runnerWithSize struct {
-	ep.Runner
-	size int
-}
-
-func (r *runnerWithSize) Returns() []ep.Type { return []ep.Type{ep.Wildcard} }
-
-func (r *runnerWithSize) ApproxSize() int {
-	return r.size
 }

--- a/runner_example_test.go
+++ b/runner_example_test.go
@@ -49,6 +49,8 @@ type runnerWithSize struct {
 	size int
 }
 
+func (r *runnerWithSize) Returns() []ep.Type { return []ep.Type{ep.Wildcard} }
+
 func (r *runnerWithSize) ApproxSize() int {
 	return r.size
 }


### PR DESCRIPTION
[task](https://app.asana.com/0/573768021211412/1116651220616812)

Compose and composeProject are far more efficient.
This PR uses composable whenever possible seamlessly for every call to `ep.Pipeline` or `ep.Project`