### PR TITLE
Avoid implicit cast and allocs if possible

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -138,8 +138,10 @@ func (set dataset) Expand(other Dataset) (Dataset, error) {
 		return set, nil
 	}
 	// when expanding with variadicNulls - don't force same length
-	isAnyVariadicNulls := set.Len() < 0 || other.Len() < 0
-	if set.Len() != other.Len() && !isAnyVariadicNulls {
+	thisLen := set.Len()
+	otherLen := other.Len()
+	isAnyVariadicNulls := thisLen < 0 || otherLen < 0
+	if thisLen != otherLen && !isAnyVariadicNulls {
 		return nil, errMismatch
 	}
 	otherCols := other.(dataset)
@@ -368,8 +370,9 @@ func (set dataset) Strings() []string {
 // If no columns provided, all columns are used
 func ColumnStrings(set Dataset, cols ...int) [][]string {
 	if len(cols) == 0 {
-		cols = make([]int, set.Width())
-		for i := 0; i < set.Width(); i++ {
+		setWidth := set.Width()
+		cols = make([]int, setWidth)
+		for i := 0; i < setWidth; i++ {
 			cols[i] = i
 		}
 	}

--- a/exchange_scatter.go
+++ b/exchange_scatter.go
@@ -15,8 +15,9 @@ func Scatter() Runner {
 
 func (ex *exchange) encodeScatter(data Dataset) error {
 	amountOfPeers := len(ex.encs)
-	peersWithLargerBatch := data.Len() % amountOfPeers
-	batchSize := data.Len() / amountOfPeers
+	dataLen := data.Len()
+	peersWithLargerBatch := dataLen % amountOfPeers
+	batchSize := dataLen / amountOfPeers
 	start := 0
 	var err error
 
@@ -31,7 +32,7 @@ func (ex *exchange) encodeScatter(data Dataset) error {
 	}
 
 	// send data batch size
-	for i := peersWithLargerBatch; i < amountOfPeers && start < data.Len(); i++ {
+	for i := peersWithLargerBatch; i < amountOfPeers && start < dataLen; i++ {
 		end := start + batchSize
 		err = ex.encodeNext(data.Slice(start, end))
 		if err != nil {

--- a/rows.go
+++ b/rows.go
@@ -100,14 +100,11 @@ func (r *rows) Next(dest []driver.Value) error {
 	}
 
 	// build the batch of data
-	dataWidth := data.Width()
-	columnar := make([][]string, dataWidth)
-	for i := 0; i < dataWidth; i++ {
-		columnar[i] = data.At(i).Strings()
-	}
+	columnar := ColumnStrings(data)
 
 	// transpose the columnar strings to rows of strings for the buffer.
 	rows := make([][]string, data.Len())
+	dataWidth := data.Width()
 	for i := range rows {
 		row := make([]string, dataWidth)
 		for j := range row {

--- a/rows.go
+++ b/rows.go
@@ -100,15 +100,16 @@ func (r *rows) Next(dest []driver.Value) error {
 	}
 
 	// build the batch of data
-	var columnar [][]string
-	for i := 0; i < data.Width(); i++ {
-		columnar = append(columnar, data.At(i).Strings())
+	dataWidth := data.Width()
+	columnar := make([][]string, dataWidth)
+	for i := 0; i < dataWidth; i++ {
+		columnar[i] = data.At(i).Strings()
 	}
 
 	// transpose the columnar strings to rows of strings for the buffer.
 	rows := make([][]string, data.Len())
 	for i := range rows {
-		row := make([]string, data.Width())
+		row := make([]string, dataWidth)
 		for j := range row {
 			row[j] = columnar[j][i]
 		}


### PR DESCRIPTION
[Task](https://app.asana.com/0/573768021211412/1121420027311669/f)

This PR replaces a couple of interface calls with more efficient expressions. It also improves columns allocation in `Rows`.