### PR TITLE
avoid allocations and casting in ColumnStrings

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -366,20 +366,32 @@ func (set dataset) Strings() []string {
 	return res
 }
 
-// ColumnStrings returns string values of selected columns of a provided dataset.
-// If no columns provided, all columns are used
-func ColumnStrings(set Dataset, cols ...int) [][]string {
-	if len(cols) == 0 {
-		setWidth := set.Width()
-		cols = make([]int, setWidth)
-		for i := 0; i < setWidth; i++ {
-			cols[i] = i
-		}
+func (set dataset) columnStrings() [][]string {
+	stringValues := make([][]string, len(set))
+	for i, c := range set {
+		stringValues[i] = c.Strings()
 	}
+	return stringValues
+}
 
+// ColumnStringsPartial returns string values of selected columns of a provided dataset
+func ColumnStringsPartial(set Dataset, cols []int) [][]string {
 	stringValues := make([][]string, len(cols))
 	for i, col := range cols {
 		stringValues[i] = set.At(col).Strings()
+	}
+	return stringValues
+}
+
+// ColumnStrings returns string values of all columns of a provided dataset
+func ColumnStrings(set Dataset) [][]string {
+	if d, isSimpleDataset := set.(dataset); isSimpleDataset {
+		return d.columnStrings()
+	}
+	width := set.Width()
+	stringValues := make([][]string, width)
+	for i := 0; i < width; i++ {
+		stringValues[i] = set.At(i).Strings()
 	}
 	return stringValues
 }

--- a/dataset_test.go
+++ b/dataset_test.go
@@ -149,21 +149,35 @@ func TestColumnStrings(t *testing.T) {
 	d1 := strs([]string{"1", "2", "4", "0", "3", "1", "1"})
 	d2 := strs([]string{"a", "b", "c", "", "e", "f", "g"})
 	dataset := ep.NewDataset(d1, d2)
+	wrappedDataset := fixedData{dataset}
 
-	t.Run("AllColumns", func(t *testing.T) {
+	t.Run("SimpleDataset", func(t *testing.T) {
 		require.Equal(t, [][]string{d1, d2}, ep.ColumnStrings(dataset))
 	})
+	t.Run("WrappedDataset", func(t *testing.T) {
+		require.Equal(t, [][]string{d1, d2}, ep.ColumnStrings(wrappedDataset))
+	})
+}
+
+func TestColumnStringsPartial(t *testing.T) {
+	d1 := strs([]string{"1", "2", "4", "0", "3", "1", "1"})
+	d2 := strs([]string{"a", "b", "c", "", "e", "f", "g"})
+	dataset := ep.NewDataset(d1, d2)
 
 	t.Run("FirstColumn", func(t *testing.T) {
-		require.Equal(t, [][]string{d1}, ep.ColumnStrings(dataset, 0))
+		require.Equal(t, [][]string{d1}, ep.ColumnStringsPartial(dataset, []int{0}))
 	})
 
 	t.Run("SecondColumn", func(t *testing.T) {
-		require.Equal(t, [][]string{d2}, ep.ColumnStrings(dataset, 1))
+		require.Equal(t, [][]string{d2}, ep.ColumnStringsPartial(dataset, []int{1}))
 	})
 
 	t.Run("BothColumns", func(t *testing.T) {
-		require.Equal(t, [][]string{d1, d2}, ep.ColumnStrings(dataset, 0, 1))
+		require.Equal(t, [][]string{d1, d2}, ep.ColumnStringsPartial(dataset, []int{0, 1}))
+	})
+
+	t.Run("DifferentOrder", func(t *testing.T) {
+		require.Equal(t, [][]string{d2, d1}, ep.ColumnStringsPartial(dataset, []int{1, 0}))
 	})
 }
 

--- a/exchange_partition.go
+++ b/exchange_partition.go
@@ -67,7 +67,7 @@ func (ex *exchange) encodePartition(e interface{}) error {
 
 func (ex *exchange) addEndpointsToData(data Dataset) (*dataWithEndpoints, error) {
 	dataLen := data.Len()
-	stringValues := ColumnStrings(data, ex.PartitionCols...)
+	stringValues := ColumnStringsPartial(data, ex.PartitionCols)
 	endpoints := make([]string, dataLen)
 	for row := 0; row < dataLen; row++ {
 		hash := ex.getRowHash(stringValues, row)


### PR DESCRIPTION
[task](https://app.asana.com/0/573768021211412/1121714234603823)

ColumnStrings is frequently used, so minor optimizations are required here :)
avoid allocations and casting in ColumnStrings