### PR TITLE
Reduce the use of Expand in project

### DIFF
--- a/dataset.go
+++ b/dataset.go
@@ -137,18 +137,29 @@ func (set dataset) Expand(other Dataset) (Dataset, error) {
 	} else if other == nil {
 		return set, nil
 	}
-	// when expanding with variadicNulls - don't force same length
-	thisLen := set.Len()
-	otherLen := other.Len()
-	isAnyVariadicNulls := thisLen < 0 || otherLen < 0
-	if thisLen != otherLen && !isAnyVariadicNulls {
-		return nil, errMismatch
+
+	_, err := verifySameLength(set.Len(), other.Len())
+	if err != nil {
+		return nil, err
 	}
+
 	otherCols := other.(dataset)
 	newDataset := make(dataset, 0, len(set)+len(otherCols))
 	newDataset = append(newDataset, set...)
 	newDataset = append(newDataset, otherCols...)
 	return newDataset, nil
+}
+
+func verifySameLength(len1, len2 int) (int, error) {
+	// when expanding with variadicNulls - don't force same length
+	isAnyVariadicNulls := len1 < 0 || len2 < 0
+	if !isAnyVariadicNulls && len1 != len2 {
+		return -1, errMismatch
+	}
+	if len1 == -1 {
+		return len2, nil
+	}
+	return len1, nil
 }
 
 // Split returns two datasets, with requested second width

--- a/project.go
+++ b/project.go
@@ -184,7 +184,7 @@ func (rs project) Run(ctx context.Context, inp, out chan Dataset) (err error) {
 			}
 
 			if open {
-				resultLen, err = rs.verifySameLength(resultLen, curr.Len())
+				resultLen, err = verifySameLength(resultLen, curr.Len())
 				if err != nil {
 					return err
 				}
@@ -240,18 +240,6 @@ func (rs project) useDummySingleton() {
 			rs[i] = dummyRunnerSingleton
 		}
 	}
-}
-
-func (rs project) verifySameLength(len1, len2 int) (int, error) {
-	// when expanding with variadicNulls - don't force same length
-	isAnyVariadicNulls := len1 < 0 || len2 < 0
-	if !isAnyVariadicNulls && len1 != len2 {
-		return -1, errMismatch
-	}
-	if len1 == -1 {
-		return len2, nil
-	}
-	return len1, nil
 }
 
 // dummyRunnerSingleton is a runner that does nothing and just returns immediately

--- a/project.go
+++ b/project.go
@@ -197,7 +197,8 @@ func (rs project) Run(ctx context.Context, inp, out chan Dataset) (err error) {
 						return err
 					}
 				} else {
-					for j := 0; j < curr.Width(); j++ {
+					currWidth := curr.Width()
+					for j := 0; j < currWidth; j++ {
 						result[i] = curr.At(j)
 						i++
 					}


### PR DESCRIPTION
In run time (not in plan time), I changed the implementation of Run() such that we won't use Expand() method each time, but only on the first time of each batch. After the first time, we allocate a Data array of size equals to the width of the data from the first iteration.

**PPROF** results, before and after, can be seen in the PR's [Task](https://app.asana.com/0/573768021211412/1123190355912217)

A possible improvement to the PR is to implement it in **plan time**