### PR TITLE
fix null idx check in TestData_CopyNTimes_withNulls_

### DIFF
--- a/eptest/data.go
+++ b/eptest/data.go
@@ -182,7 +182,7 @@ func VerifyDataNullsHandling(t *testing.T, data ep.Data, expectedNullString stri
 	})
 
 	t.Run("TestData_CopyNTimes_withNulls_"+data.Type().String(), func(t *testing.T) {
-		newNullIdx := nullIdx + 2
+		newNullIdx := nullIdx + 3
 		require.False(t, data.IsNull(newNullIdx))
 		require.NotEqual(t, data.IsNull(nullIdx), data.IsNull(newNullIdx))
 


### PR DESCRIPTION
Part of [asana task](https://app.asana.com/0/573768021211412/1123376548775050)

Copy already changed the newNullIdx in the current data that's why we receive an error in `	require.False(t, data.IsNull(newNullIdx))
`
we should look on another index for this test.